### PR TITLE
feat: Path Builder API (feat-061)

### DIFF
--- a/creator/path.go
+++ b/creator/path.go
@@ -1,27 +1,621 @@
 package creator
 
-// Path represents a vector path for drawing and clipping.
+import (
+	"fmt"
+	"math"
+)
+
+// Path represents a vector path for drawing, filling, and clipping.
 //
-// This is a placeholder for feat-053 (ClipPath).
-// Full implementation will include:
-//   - MoveTo, LineTo, CurveTo, Arc, Close
-//   - Fill rule (NonZero, EvenOdd)
-//   - Path building and transformation
+// A Path consists of one or more subpaths, where each subpath is a sequence
+// of connected lines and curves. Subpaths can be open or closed.
 //
-// Example (planned for feat-053):
+// Path uses a fluent builder API for easy construction:
 //
-//	path := NewPath()
-//	path.MoveTo(0, 0)
-//	path.LineTo(100, 0)
-//	path.LineTo(50, 100)
-//	path.Close()
+//	path := NewPath().
+//	    MoveTo(100, 100).
+//	    LineTo(200, 100).
+//	    QuadraticTo(250, 150, 200, 200).
+//	    CubicTo(150, 250, 100, 250, 100, 200).
+//	    Close()
+//
+// Shape helpers provide shortcuts for common shapes:
+//
+//	circle := NewPath().AddCircle(Point{150, 150}, 50)
+//	rect := NewPath().AddRect(Rect{X: 10, Y: 10, Width: 100, Height: 50})
+//
+// Reference: PDF 1.7 Specification, Section 8.5 (Path Construction).
 type Path struct {
-	// TODO: Implement in feat-053
+	// commands stores the path construction commands.
+	commands []pathCommand
+
+	// currentPoint tracks the current point for relative operations.
+	// This is updated by MoveTo, LineTo, CurveTo, etc.
+	currentPoint Point
+
+	// subpathStart tracks the starting point of the current subpath.
+	// Used by Close() to connect back to the subpath start.
+	subpathStart Point
+
+	// hasCurrentPoint indicates whether currentPoint is valid.
+	// False after NewPath() and Close(), true after MoveTo/LineTo/etc.
+	hasCurrentPoint bool
+}
+
+// pathCommand represents a single path construction operation.
+//
+// Each command corresponds to a PDF path operator (m, l, c, v, y, h, re).
+type pathCommand struct {
+	op   pathOp
+	args []float64
+}
+
+// pathOp defines the path operation type.
+type pathOp int
+
+const (
+	pathOpMoveTo pathOp = iota
+	pathOpLineTo
+	pathOpCubicTo // Cubic Bézier curve
+	pathOpClose   // Close subpath
+	pathOpRect    // Rectangle (special case for optimization)
+)
+
+// String returns the PDF operator for this path operation.
+func (op pathOp) String() string {
+	switch op {
+	case pathOpMoveTo:
+		return "m"
+	case pathOpLineTo:
+		return "l"
+	case pathOpCubicTo:
+		return "c"
+	case pathOpClose:
+		return "h"
+	case pathOpRect:
+		return "re"
+	default:
+		return "?"
+	}
 }
 
 // NewPath creates a new empty path.
 //
-// This is a placeholder for feat-053.
+// The path starts with no current point. Use MoveTo to start a new subpath.
+//
+// Example:
+//
+//	path := NewPath()
+//	path.MoveTo(100, 100)
+//	path.LineTo(200, 200)
 func NewPath() *Path {
-	return &Path{}
+	return &Path{
+		commands:        make([]pathCommand, 0, 8), // Pre-allocate for typical paths
+		hasCurrentPoint: false,
+	}
+}
+
+// MoveTo starts a new subpath at the specified point.
+//
+// If there is a current subpath, it is left open (not closed).
+// The specified point becomes the current point and the subpath start.
+//
+// PDF operator: x y m
+//
+// Parameters:
+//   - x, y: Coordinates of the new subpath start
+//
+// Example:
+//
+//	path := NewPath().MoveTo(100, 100)
+func (p *Path) MoveTo(x, y float64) *Path {
+	p.commands = append(p.commands, pathCommand{
+		op:   pathOpMoveTo,
+		args: []float64{x, y},
+	})
+	p.currentPoint = Point{X: x, Y: y}
+	p.subpathStart = Point{X: x, Y: y}
+	p.hasCurrentPoint = true
+	return p
+}
+
+// LineTo appends a straight line to the path.
+//
+// The line goes from the current point to the specified point.
+// The specified point becomes the new current point.
+//
+// PDF operator: x y l
+//
+// Panics if there is no current point (call MoveTo first).
+//
+// Parameters:
+//   - x, y: Coordinates of the line endpoint
+//
+// Example:
+//
+//	path := NewPath().
+//	    MoveTo(100, 100).
+//	    LineTo(200, 100).
+//	    LineTo(200, 200)
+func (p *Path) LineTo(x, y float64) *Path {
+	if !p.hasCurrentPoint {
+		panic("LineTo called without current point (call MoveTo first)")
+	}
+	p.commands = append(p.commands, pathCommand{
+		op:   pathOpLineTo,
+		args: []float64{x, y},
+	})
+	p.currentPoint = Point{X: x, Y: y}
+	return p
+}
+
+// CubicTo appends a cubic Bézier curve to the path.
+//
+// The curve goes from the current point to (x, y) using (c1x, c1y)
+// and (c2x, c2y) as control points.
+//
+// PDF operator: c1x c1y c2x c2y x y c
+//
+// Panics if there is no current point (call MoveTo first).
+//
+// Parameters:
+//   - c1x, c1y: First control point
+//   - c2x, c2y: Second control point
+//   - x, y: Endpoint of the curve
+//
+// Example:
+//
+//	// Smooth S-curve
+//	path := NewPath().
+//	    MoveTo(100, 100).
+//	    CubicTo(150, 50, 200, 150, 250, 100)
+func (p *Path) CubicTo(c1x, c1y, c2x, c2y, x, y float64) *Path {
+	if !p.hasCurrentPoint {
+		panic("CubicTo called without current point (call MoveTo first)")
+	}
+	p.commands = append(p.commands, pathCommand{
+		op:   pathOpCubicTo,
+		args: []float64{c1x, c1y, c2x, c2y, x, y},
+	})
+	p.currentPoint = Point{X: x, Y: y}
+	return p
+}
+
+// QuadraticTo appends a quadratic Bézier curve to the path.
+//
+// The curve goes from the current point to (x, y) using (cx, cy)
+// as the control point.
+//
+// PDF does not support quadratic Bézier curves directly, so this method
+// converts the quadratic curve to a cubic curve using the standard algorithm:
+//
+//	CP1 = P0 + 2/3 * (CP - P0)
+//	CP2 = P1 + 2/3 * (CP - P1)
+//
+// Where P0 is the current point, CP is (cx, cy), and P1 is (x, y).
+//
+// Panics if there is no current point (call MoveTo first).
+//
+// Parameters:
+//   - cx, cy: Control point
+//   - x, y: Endpoint of the curve
+//
+// Example:
+//
+//	// Smooth parabolic curve
+//	path := NewPath().
+//	    MoveTo(100, 100).
+//	    QuadraticTo(150, 50, 200, 100)
+//
+// Reference: Converting between quadratic and cubic curves.
+func (p *Path) QuadraticTo(cx, cy, x, y float64) *Path {
+	if !p.hasCurrentPoint {
+		panic("QuadraticTo called without current point (call MoveTo first)")
+	}
+
+	// Convert quadratic to cubic Bézier
+	// Quadratic: P0 → CP → P1
+	// Cubic:    P0 → CP1 → CP2 → P1
+	// Where:
+	//   CP1 = P0 + 2/3 * (CP - P0)
+	//   CP2 = P1 + 2/3 * (CP - P1)
+
+	p0 := p.currentPoint
+	cp1x := p0.X + (2.0/3.0)*(cx-p0.X)
+	cp1y := p0.Y + (2.0/3.0)*(cy-p0.Y)
+	cp2x := x + (2.0/3.0)*(cx-x)
+	cp2y := y + (2.0/3.0)*(cy-y)
+
+	return p.CubicTo(cp1x, cp1y, cp2x, cp2y, x, y)
+}
+
+// Close closes the current subpath.
+//
+// A straight line is appended from the current point to the subpath start.
+// The subpath is marked as closed for filling purposes.
+//
+// PDF operator: h
+//
+// After Close(), there is no current point (call MoveTo to start a new subpath).
+//
+// Example:
+//
+//	// Closed triangle
+//	path := NewPath().
+//	    MoveTo(100, 100).
+//	    LineTo(200, 100).
+//	    LineTo(150, 200).
+//	    Close()
+func (p *Path) Close() *Path {
+	if !p.hasCurrentPoint {
+		// No current point, nothing to close
+		return p
+	}
+	p.commands = append(p.commands, pathCommand{
+		op:   pathOpClose,
+		args: nil,
+	})
+	// After close, current point becomes invalid
+	p.hasCurrentPoint = false
+	return p
+}
+
+// AddRect adds a rectangle to the path.
+//
+// This is a convenience method that adds a closed rectangular subpath.
+// The rectangle is drawn counterclockwise (for NonZero fill rule).
+//
+// PDF operator: x y width height re
+//
+// Parameters:
+//   - rect: Rectangle to add
+//
+// Example:
+//
+//	path := NewPath().
+//	    AddRect(Rect{X: 10, Y: 10, Width: 100, Height: 50}).
+//	    AddRect(Rect{X: 150, Y: 10, Width: 100, Height: 50})
+func (p *Path) AddRect(rect Rect) *Path {
+	// Use PDF's optimized rectangle operator
+	p.commands = append(p.commands, pathCommand{
+		op:   pathOpRect,
+		args: []float64{rect.X, rect.Y, rect.Width, rect.Height},
+	})
+	// Rectangle is a closed subpath, so no current point after
+	p.hasCurrentPoint = false
+	return p
+}
+
+// AddRoundedRect adds a rounded rectangle to the path.
+//
+// The rectangle has rounded corners with the specified radius.
+// Corners are drawn as quarter-circle arcs.
+//
+// Parameters:
+//   - rect: Rectangle bounds
+//   - radius: Corner radius (must be non-negative)
+//
+// Example:
+//
+//	// Rounded rectangle with 10-unit radius corners
+//	path := NewPath().AddRoundedRect(
+//	    Rect{X: 10, Y: 10, Width: 100, Height: 50},
+//	    10,
+//	)
+func (p *Path) AddRoundedRect(rect Rect, radius float64) *Path {
+	if radius <= 0 {
+		return p.AddRect(rect)
+	}
+
+	// Clamp radius to not exceed half the smallest dimension
+	maxRadius := math.Min(rect.Width/2, rect.Height/2)
+	if radius > maxRadius {
+		radius = maxRadius
+	}
+
+	x, y, w, h := rect.X, rect.Y, rect.Width, rect.Height
+
+	// Draw rounded rectangle as 4 lines + 4 arcs
+	// Start at top-left corner (after radius)
+	p.MoveTo(x+radius, y)
+
+	// Top edge + top-right corner
+	p.LineTo(x+w-radius, y)
+	p.addArc(x+w-radius, y+radius, radius, 270, 360)
+
+	// Right edge + bottom-right corner
+	p.LineTo(x+w, y+h-radius)
+	p.addArc(x+w-radius, y+h-radius, radius, 0, 90)
+
+	// Bottom edge + bottom-left corner
+	p.LineTo(x+radius, y+h)
+	p.addArc(x+radius, y+h-radius, radius, 90, 180)
+
+	// Left edge + top-left corner
+	p.LineTo(x, y+radius)
+	p.addArc(x+radius, y+radius, radius, 180, 270)
+
+	return p.Close()
+}
+
+// AddCircle adds a circle to the path.
+//
+// The circle is approximated using 4 cubic Bézier curves.
+// This provides a very accurate approximation (error < 0.06% of radius).
+//
+// Parameters:
+//   - center: Circle center point
+//   - radius: Circle radius (must be positive)
+//
+// Example:
+//
+//	path := NewPath().AddCircle(Point{150, 150}, 50)
+func (p *Path) AddCircle(center Point, radius float64) *Path {
+	if radius <= 0 {
+		panic(fmt.Sprintf("AddCircle: radius must be positive, got: %f", radius))
+	}
+	return p.AddEllipse(Rect{
+		X:      center.X - radius,
+		Y:      center.Y - radius,
+		Width:  radius * 2,
+		Height: radius * 2,
+	})
+}
+
+// AddEllipse adds an ellipse to the path.
+//
+// The ellipse is inscribed in the specified rectangle.
+// It is approximated using 4 cubic Bézier curves.
+//
+// Parameters:
+//   - rect: Bounding rectangle of the ellipse
+//
+// Example:
+//
+//	// Horizontal ellipse
+//	path := NewPath().AddEllipse(Rect{X: 10, Y: 10, Width: 200, Height: 100})
+func (p *Path) AddEllipse(rect Rect) *Path {
+	// Magic number for approximating a circle with cubic Bézier curves
+	// k = 4 * (sqrt(2) - 1) / 3 ≈ 0.5522847498
+	const k = 0.5522847498
+
+	cx := rect.X + rect.Width/2
+	cy := rect.Y + rect.Height/2
+	rx := rect.Width / 2
+	ry := rect.Height / 2
+
+	// Control point offset for each axis
+	kx := rx * k
+	ky := ry * k
+
+	// Start at rightmost point (3 o'clock)
+	p.MoveTo(cx+rx, cy)
+
+	// Top-right quadrant (3 o'clock → 12 o'clock)
+	p.CubicTo(cx+rx, cy-ky, cx+kx, cy-ry, cx, cy-ry)
+
+	// Top-left quadrant (12 o'clock → 9 o'clock)
+	p.CubicTo(cx-kx, cy-ry, cx-rx, cy-ky, cx-rx, cy)
+
+	// Bottom-left quadrant (9 o'clock → 6 o'clock)
+	p.CubicTo(cx-rx, cy+ky, cx-kx, cy+ry, cx, cy+ry)
+
+	// Bottom-right quadrant (6 o'clock → 3 o'clock)
+	p.CubicTo(cx+kx, cy+ry, cx+rx, cy+ky, cx+rx, cy)
+
+	return p.Close()
+}
+
+// AddArc adds a circular arc to the path.
+//
+// The arc is centered at 'center' with the specified radius.
+// It spans from startAngle to endAngle (in degrees).
+// Angles are measured counterclockwise from the positive X axis.
+//
+// If there is a current point, a line is drawn from the current point
+// to the arc start. Otherwise, MoveTo is used to start at the arc.
+//
+// Parameters:
+//   - center: Arc center point
+//   - radius: Arc radius (must be positive)
+//   - startAngle: Starting angle in degrees (0 = right, 90 = top)
+//   - endAngle: Ending angle in degrees
+//
+// Example:
+//
+//	// Quarter circle arc (90 degrees)
+//	path := NewPath().
+//	    MoveTo(150, 150).
+//	    AddArc(Point{150, 150}, 50, 0, 90)
+func (p *Path) AddArc(center Point, radius, startAngle, endAngle float64) *Path {
+	if radius <= 0 {
+		panic(fmt.Sprintf("AddArc: radius must be positive, got: %f", radius))
+	}
+	p.addArc(center.X, center.Y, radius, startAngle, endAngle)
+	return p
+}
+
+// addArc is the internal implementation of AddArc.
+// It adds an arc using cubic Bézier curve approximation.
+func (p *Path) addArc(cx, cy, radius, startAngle, endAngle float64) {
+	// Normalize angles
+	for endAngle < startAngle {
+		endAngle += 360
+	}
+
+	// Convert to radians
+	start := startAngle * math.Pi / 180
+	end := endAngle * math.Pi / 180
+	totalAngle := end - start
+
+	// Split arc into segments (max 90 degrees each for accuracy)
+	segments := int(math.Ceil(totalAngle / (math.Pi / 2)))
+	if segments < 1 {
+		segments = 1
+	}
+	anglePerSegment := totalAngle / float64(segments)
+
+	// Calculate first point
+	x0 := cx + radius*math.Cos(start)
+	y0 := cy + radius*math.Sin(start)
+
+	if !p.hasCurrentPoint {
+		p.MoveTo(x0, y0)
+	} else {
+		p.LineTo(x0, y0)
+	}
+
+	// Draw each segment as a cubic Bézier
+	for i := 0; i < segments; i++ {
+		a1 := start + float64(i)*anglePerSegment
+		a2 := start + float64(i+1)*anglePerSegment
+
+		// Calculate control points using the arc approximation formula
+		alpha := math.Sin(a2-a1) * (math.Sqrt(4+3*math.Tan((a2-a1)/2)*math.Tan((a2-a1)/2)) - 1) / 3
+
+		x1 := x0
+		y1 := y0
+		x2 := cx + radius*math.Cos(a2)
+		y2 := cy + radius*math.Sin(a2)
+
+		q1x := x1 - alpha*radius*math.Sin(a1)
+		q1y := y1 + alpha*radius*math.Cos(a1)
+		q2x := x2 + alpha*radius*math.Sin(a2)
+		q2y := y2 - alpha*radius*math.Cos(a2)
+
+		p.CubicTo(q1x, q1y, q2x, q2y, x2, y2)
+
+		x0 = x2
+		y0 = y2
+	}
+}
+
+// IsEmpty returns true if the path has no commands.
+//
+// Example:
+//
+//	path := NewPath()
+//	fmt.Println(path.IsEmpty()) // true
+//	path.MoveTo(0, 0)
+//	fmt.Println(path.IsEmpty()) // false
+func (p *Path) IsEmpty() bool {
+	return len(p.commands) == 0
+}
+
+// Bounds returns the bounding box of the path.
+//
+// The bounding box is the smallest rectangle that contains all points
+// in the path. This includes line endpoints and Bézier curve control points
+// (which may be outside the actual curve).
+//
+// Returns a zero Rect if the path is empty.
+//
+// Example:
+//
+//	path := NewPath().
+//	    MoveTo(10, 10).
+//	    LineTo(100, 50).
+//	    LineTo(10, 90)
+//	bounds := path.Bounds() // Rect{X: 10, Y: 10, Width: 90, Height: 80}
+func (p *Path) Bounds() Rect {
+	if len(p.commands) == 0 {
+		return Rect{}
+	}
+
+	minX, minY := math.MaxFloat64, math.MaxFloat64
+	maxX, maxY := -math.MaxFloat64, -math.MaxFloat64
+
+	for _, cmd := range p.commands {
+		switch cmd.op {
+		case pathOpMoveTo, pathOpLineTo:
+			// x, y
+			x, y := cmd.args[0], cmd.args[1]
+			minX, maxX = math.Min(minX, x), math.Max(maxX, x)
+			minY, maxY = math.Min(minY, y), math.Max(maxY, y)
+
+		case pathOpCubicTo:
+			// c1x, c1y, c2x, c2y, x, y
+			for i := 0; i < 6; i += 2 {
+				x, y := cmd.args[i], cmd.args[i+1]
+				minX, maxX = math.Min(minX, x), math.Max(maxX, x)
+				minY, maxY = math.Min(minY, y), math.Max(maxY, y)
+			}
+
+		case pathOpRect:
+			// x, y, width, height
+			x, y, w, h := cmd.args[0], cmd.args[1], cmd.args[2], cmd.args[3]
+			minX, maxX = math.Min(minX, x), math.Max(maxX, x+w)
+			minY, maxY = math.Min(minY, y), math.Max(maxY, y+h)
+
+		case pathOpClose:
+			// No coordinates
+		}
+	}
+
+	if minX > maxX {
+		// No coordinates found
+		return Rect{}
+	}
+
+	return Rect{
+		X:      minX,
+		Y:      minY,
+		Width:  maxX - minX,
+		Height: maxY - minY,
+	}
+}
+
+// Clone creates a deep copy of the path.
+//
+// The cloned path is independent of the original.
+//
+// Example:
+//
+//	original := NewPath().MoveTo(0, 0).LineTo(100, 100)
+//	clone := original.Clone()
+//	clone.LineTo(200, 0) // Does not affect original
+func (p *Path) Clone() *Path {
+	clone := &Path{
+		commands:        make([]pathCommand, len(p.commands)),
+		currentPoint:    p.currentPoint,
+		subpathStart:    p.subpathStart,
+		hasCurrentPoint: p.hasCurrentPoint,
+	}
+
+	for i, cmd := range p.commands {
+		clone.commands[i] = pathCommand{
+			op:   cmd.op,
+			args: append([]float64(nil), cmd.args...), // Deep copy args
+		}
+	}
+
+	return clone
+}
+
+// toPDFOperators converts the path to PDF content stream operators.
+//
+// This is an internal method used by Surface to render the path.
+func (p *Path) toPDFOperators() string {
+	if len(p.commands) == 0 {
+		return ""
+	}
+
+	result := ""
+	for _, cmd := range p.commands {
+		switch cmd.op {
+		case pathOpMoveTo:
+			result += fmt.Sprintf("%.2f %.2f m\n", cmd.args[0], cmd.args[1])
+		case pathOpLineTo:
+			result += fmt.Sprintf("%.2f %.2f l\n", cmd.args[0], cmd.args[1])
+		case pathOpCubicTo:
+			result += fmt.Sprintf("%.2f %.2f %.2f %.2f %.2f %.2f c\n",
+				cmd.args[0], cmd.args[1], cmd.args[2], cmd.args[3], cmd.args[4], cmd.args[5])
+		case pathOpClose:
+			result += "h\n"
+		case pathOpRect:
+			result += fmt.Sprintf("%.2f %.2f %.2f %.2f re\n",
+				cmd.args[0], cmd.args[1], cmd.args[2], cmd.args[3])
+		}
+	}
+	return result
 }

--- a/creator/path_test.go
+++ b/creator/path_test.go
@@ -1,0 +1,702 @@
+package creator
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// Test NewPath creates an empty path
+func TestNewPath(t *testing.T) {
+	path := NewPath()
+	if path == nil {
+		t.Fatal("NewPath returned nil")
+	}
+	if !path.IsEmpty() {
+		t.Error("NewPath should create empty path")
+	}
+	if path.hasCurrentPoint {
+		t.Error("NewPath should have no current point")
+	}
+}
+
+// Test MoveTo
+func TestPath_MoveTo(t *testing.T) {
+	path := NewPath().MoveTo(100, 200)
+
+	if path.IsEmpty() {
+		t.Error("Path should not be empty after MoveTo")
+	}
+	if !path.hasCurrentPoint {
+		t.Error("MoveTo should set current point")
+	}
+	if path.currentPoint.X != 100 || path.currentPoint.Y != 200 {
+		t.Errorf("MoveTo: expected (100, 200), got (%f, %f)",
+			path.currentPoint.X, path.currentPoint.Y)
+	}
+	if path.subpathStart.X != 100 || path.subpathStart.Y != 200 {
+		t.Error("MoveTo should set subpath start")
+	}
+}
+
+// Test LineTo
+func TestPath_LineTo(t *testing.T) {
+	path := NewPath().
+		MoveTo(100, 100).
+		LineTo(200, 100).
+		LineTo(200, 200)
+
+	if len(path.commands) != 3 {
+		t.Errorf("Expected 3 commands, got %d", len(path.commands))
+	}
+	if path.currentPoint.X != 200 || path.currentPoint.Y != 200 {
+		t.Errorf("LineTo: expected (200, 200), got (%f, %f)",
+			path.currentPoint.X, path.currentPoint.Y)
+	}
+}
+
+// Test LineTo panics without current point
+func TestPath_LineTo_Panic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("LineTo should panic without current point")
+		}
+	}()
+
+	path := NewPath()
+	path.LineTo(100, 100) // Should panic
+}
+
+// Test CubicTo
+func TestPath_CubicTo(t *testing.T) {
+	path := NewPath().
+		MoveTo(100, 100).
+		CubicTo(150, 50, 200, 150, 250, 100)
+
+	if len(path.commands) != 2 {
+		t.Errorf("Expected 2 commands, got %d", len(path.commands))
+	}
+	if path.commands[1].op != pathOpCubicTo {
+		t.Error("Second command should be CubicTo")
+	}
+	if len(path.commands[1].args) != 6 {
+		t.Errorf("CubicTo should have 6 args, got %d", len(path.commands[1].args))
+	}
+	if path.currentPoint.X != 250 || path.currentPoint.Y != 100 {
+		t.Errorf("CubicTo: expected (250, 100), got (%f, %f)",
+			path.currentPoint.X, path.currentPoint.Y)
+	}
+}
+
+// Test CubicTo panics without current point
+func TestPath_CubicTo_Panic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("CubicTo should panic without current point")
+		}
+	}()
+
+	path := NewPath()
+	path.CubicTo(150, 50, 200, 150, 250, 100) // Should panic
+}
+
+// Test QuadraticTo converts to cubic correctly
+func TestPath_QuadraticTo(t *testing.T) {
+	path := NewPath().
+		MoveTo(100, 100).
+		QuadraticTo(150, 50, 200, 100)
+
+	if len(path.commands) != 2 {
+		t.Errorf("Expected 2 commands, got %d", len(path.commands))
+	}
+
+	// QuadraticTo should convert to CubicTo internally
+	if path.commands[1].op != pathOpCubicTo {
+		t.Error("QuadraticTo should convert to CubicTo")
+	}
+	if len(path.commands[1].args) != 6 {
+		t.Errorf("CubicTo should have 6 args, got %d", len(path.commands[1].args))
+	}
+
+	// Verify conversion formula: CP1 = P0 + 2/3 * (CP - P0)
+	// P0 = (100, 100), CP = (150, 50), P1 = (200, 100)
+	expectedCP1x := 100 + (2.0/3.0)*(150-100) // 133.33
+	expectedCP1y := 100 + (2.0/3.0)*(50-100)  // 66.67
+	expectedCP2x := 200 + (2.0/3.0)*(150-200) // 166.67
+	expectedCP2y := 100 + (2.0/3.0)*(50-100)  // 66.67
+
+	cp1x := path.commands[1].args[0]
+	cp1y := path.commands[1].args[1]
+	cp2x := path.commands[1].args[2]
+	cp2y := path.commands[1].args[3]
+
+	if math.Abs(cp1x-expectedCP1x) > 0.01 || math.Abs(cp1y-expectedCP1y) > 0.01 {
+		t.Errorf("QuadraticTo CP1: expected (%.2f, %.2f), got (%.2f, %.2f)",
+			expectedCP1x, expectedCP1y, cp1x, cp1y)
+	}
+	if math.Abs(cp2x-expectedCP2x) > 0.01 || math.Abs(cp2y-expectedCP2y) > 0.01 {
+		t.Errorf("QuadraticTo CP2: expected (%.2f, %.2f), got (%.2f, %.2f)",
+			expectedCP2x, expectedCP2y, cp2x, cp2y)
+	}
+}
+
+// Test QuadraticTo panics without current point
+func TestPath_QuadraticTo_Panic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("QuadraticTo should panic without current point")
+		}
+	}()
+
+	path := NewPath()
+	path.QuadraticTo(150, 50, 200, 100) // Should panic
+}
+
+// Test Close
+func TestPath_Close(t *testing.T) {
+	path := NewPath().
+		MoveTo(100, 100).
+		LineTo(200, 100).
+		LineTo(150, 200).
+		Close()
+
+	if len(path.commands) != 4 {
+		t.Errorf("Expected 4 commands, got %d", len(path.commands))
+	}
+	if path.commands[3].op != pathOpClose {
+		t.Error("Last command should be Close")
+	}
+	if path.hasCurrentPoint {
+		t.Error("Close should invalidate current point")
+	}
+}
+
+// Test Close with no current point is safe
+func TestPath_Close_NoCurrentPoint(t *testing.T) {
+	path := NewPath().Close() // Should not panic
+
+	if !path.IsEmpty() {
+		t.Error("Close on empty path should remain empty")
+	}
+}
+
+// Test AddRect
+func TestPath_AddRect(t *testing.T) {
+	rect := Rect{X: 10, Y: 20, Width: 100, Height: 50}
+	path := NewPath().AddRect(rect)
+
+	if len(path.commands) != 1 {
+		t.Errorf("Expected 1 command, got %d", len(path.commands))
+	}
+	if path.commands[0].op != pathOpRect {
+		t.Error("Command should be Rect")
+	}
+	if len(path.commands[0].args) != 4 {
+		t.Errorf("Rect should have 4 args, got %d", len(path.commands[0].args))
+	}
+
+	args := path.commands[0].args
+	if args[0] != rect.X || args[1] != rect.Y || args[2] != rect.Width || args[3] != rect.Height {
+		t.Error("Rect args do not match")
+	}
+
+	// Rectangle is closed, so no current point
+	if path.hasCurrentPoint {
+		t.Error("AddRect should not have current point")
+	}
+}
+
+// Test AddRoundedRect with zero radius becomes regular rect
+func TestPath_AddRoundedRect_ZeroRadius(t *testing.T) {
+	rect := Rect{X: 10, Y: 10, Width: 100, Height: 50}
+	path := NewPath().AddRoundedRect(rect, 0)
+
+	// Should use AddRect optimization
+	if len(path.commands) != 1 || path.commands[0].op != pathOpRect {
+		t.Error("AddRoundedRect with zero radius should use AddRect")
+	}
+}
+
+// Test AddRoundedRect with valid radius
+func TestPath_AddRoundedRect(t *testing.T) {
+	rect := Rect{X: 10, Y: 10, Width: 100, Height: 50}
+	path := NewPath().AddRoundedRect(rect, 10)
+
+	if len(path.commands) < 5 {
+		t.Errorf("AddRoundedRect should have multiple commands, got %d", len(path.commands))
+	}
+
+	// Should start with MoveTo
+	if path.commands[0].op != pathOpMoveTo {
+		t.Error("AddRoundedRect should start with MoveTo")
+	}
+
+	// Should end with Close
+	if path.commands[len(path.commands)-1].op != pathOpClose {
+		t.Error("AddRoundedRect should end with Close")
+	}
+}
+
+// Test AddCircle
+func TestPath_AddCircle(t *testing.T) {
+	center := Point{X: 150, Y: 150}
+	radius := 50.0
+	path := NewPath().AddCircle(center, radius)
+
+	if len(path.commands) < 5 {
+		t.Errorf("AddCircle should have multiple commands, got %d", len(path.commands))
+	}
+
+	// Should start with MoveTo
+	if path.commands[0].op != pathOpMoveTo {
+		t.Error("AddCircle should start with MoveTo")
+	}
+
+	// Should have multiple CubicTo commands (4 for a circle)
+	cubicCount := 0
+	for _, cmd := range path.commands {
+		if cmd.op == pathOpCubicTo {
+			cubicCount++
+		}
+	}
+	if cubicCount != 4 {
+		t.Errorf("AddCircle should have 4 CubicTo commands, got %d", cubicCount)
+	}
+
+	// Should end with Close
+	if path.commands[len(path.commands)-1].op != pathOpClose {
+		t.Error("AddCircle should end with Close")
+	}
+}
+
+// Test AddCircle panics with non-positive radius
+func TestPath_AddCircle_InvalidRadius(t *testing.T) {
+	tests := []struct {
+		name   string
+		radius float64
+	}{
+		{"zero radius", 0},
+		{"negative radius", -50},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("AddCircle should panic with radius %f", tt.radius)
+				}
+			}()
+
+			path := NewPath()
+			path.AddCircle(Point{150, 150}, tt.radius) // Should panic
+		})
+	}
+}
+
+// Test AddEllipse
+func TestPath_AddEllipse(t *testing.T) {
+	rect := Rect{X: 10, Y: 10, Width: 200, Height: 100}
+	path := NewPath().AddEllipse(rect)
+
+	if len(path.commands) < 5 {
+		t.Errorf("AddEllipse should have multiple commands, got %d", len(path.commands))
+	}
+
+	// Should start with MoveTo (at rightmost point)
+	if path.commands[0].op != pathOpMoveTo {
+		t.Error("AddEllipse should start with MoveTo")
+	}
+
+	// Check first point is at rightmost position (3 o'clock)
+	cx := rect.X + rect.Width/2  // 110
+	cy := rect.Y + rect.Height/2 // 60
+	rx := rect.Width / 2         // 100
+	expectedX := cx + rx         // 210
+
+	firstX := path.commands[0].args[0]
+	firstY := path.commands[0].args[1]
+
+	if math.Abs(firstX-expectedX) > 0.01 || math.Abs(firstY-cy) > 0.01 {
+		t.Errorf("AddEllipse first point: expected (%.2f, %.2f), got (%.2f, %.2f)",
+			expectedX, cy, firstX, firstY)
+	}
+
+	// Should end with Close
+	if path.commands[len(path.commands)-1].op != pathOpClose {
+		t.Error("AddEllipse should end with Close")
+	}
+}
+
+// Test AddArc
+func TestPath_AddArc(t *testing.T) {
+	center := Point{X: 150, Y: 150}
+	radius := 50.0
+	path := NewPath().AddArc(center, radius, 0, 90) // Quarter circle
+
+	if len(path.commands) < 2 {
+		t.Errorf("AddArc should have at least 2 commands, got %d", len(path.commands))
+	}
+
+	// Should start with MoveTo (no current point initially)
+	if path.commands[0].op != pathOpMoveTo {
+		t.Error("AddArc should start with MoveTo when no current point")
+	}
+
+	// Should have CubicTo commands for the arc
+	hasCubic := false
+	for _, cmd := range path.commands {
+		if cmd.op == pathOpCubicTo {
+			hasCubic = true
+			break
+		}
+	}
+	if !hasCubic {
+		t.Error("AddArc should have CubicTo commands")
+	}
+}
+
+// Test AddArc with current point draws line first
+func TestPath_AddArc_WithCurrentPoint(t *testing.T) {
+	center := Point{X: 150, Y: 150}
+	radius := 50.0
+	path := NewPath().
+		MoveTo(50, 50).
+		AddArc(center, radius, 0, 90)
+
+	// Should have MoveTo, then LineTo (to arc start), then CubicTo
+	if len(path.commands) < 3 {
+		t.Errorf("AddArc with current point should have at least 3 commands, got %d", len(path.commands))
+	}
+
+	// Second command should be LineTo (connecting current point to arc start)
+	if path.commands[1].op != pathOpLineTo {
+		t.Error("AddArc with current point should have LineTo to arc start")
+	}
+}
+
+// Test AddArc panics with invalid radius
+func TestPath_AddArc_InvalidRadius(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("AddArc should panic with non-positive radius")
+		}
+	}()
+
+	path := NewPath()
+	path.AddArc(Point{150, 150}, 0, 0, 90) // Should panic
+}
+
+// Test IsEmpty
+func TestPath_IsEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		build    func() *Path
+		expected bool
+	}{
+		{
+			name:     "new path",
+			build:    func() *Path { return NewPath() },
+			expected: true,
+		},
+		{
+			name:     "path with MoveTo",
+			build:    func() *Path { return NewPath().MoveTo(0, 0) },
+			expected: false,
+		},
+		{
+			name:     "path with LineTo",
+			build:    func() *Path { return NewPath().MoveTo(0, 0).LineTo(100, 100) },
+			expected: false,
+		},
+		{
+			name:     "path with AddRect",
+			build:    func() *Path { return NewPath().AddRect(Rect{X: 0, Y: 0, Width: 100, Height: 100}) },
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := tt.build()
+			if path.IsEmpty() != tt.expected {
+				t.Errorf("IsEmpty: expected %v, got %v", tt.expected, path.IsEmpty())
+			}
+		})
+	}
+}
+
+// Test Bounds
+func TestPath_Bounds(t *testing.T) {
+	tests := []struct {
+		name     string
+		build    func() *Path
+		expected Rect
+	}{
+		{
+			name:     "empty path",
+			build:    func() *Path { return NewPath() },
+			expected: Rect{},
+		},
+		{
+			name: "simple line",
+			build: func() *Path {
+				return NewPath().MoveTo(10, 20).LineTo(100, 80)
+			},
+			expected: Rect{X: 10, Y: 20, Width: 90, Height: 60},
+		},
+		{
+			name: "triangle",
+			build: func() *Path {
+				return NewPath().
+					MoveTo(50, 10).
+					LineTo(90, 90).
+					LineTo(10, 90).
+					Close()
+			},
+			expected: Rect{X: 10, Y: 10, Width: 80, Height: 80},
+		},
+		{
+			name: "rectangle",
+			build: func() *Path {
+				return NewPath().AddRect(Rect{X: 20, Y: 30, Width: 100, Height: 50})
+			},
+			expected: Rect{X: 20, Y: 30, Width: 100, Height: 50},
+		},
+		{
+			name: "cubic bezier",
+			build: func() *Path {
+				return NewPath().
+					MoveTo(0, 0).
+					CubicTo(50, -50, 100, 150, 150, 100)
+			},
+			// Bounds include control points
+			expected: Rect{X: 0, Y: -50, Width: 150, Height: 200},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := tt.build()
+			bounds := path.Bounds()
+
+			if math.Abs(bounds.X-tt.expected.X) > 0.01 ||
+				math.Abs(bounds.Y-tt.expected.Y) > 0.01 ||
+				math.Abs(bounds.Width-tt.expected.Width) > 0.01 ||
+				math.Abs(bounds.Height-tt.expected.Height) > 0.01 {
+				t.Errorf("Bounds: expected %+v, got %+v", tt.expected, bounds)
+			}
+		})
+	}
+}
+
+// Test Clone
+func TestPath_Clone(t *testing.T) {
+	original := NewPath().
+		MoveTo(100, 100).
+		LineTo(200, 100).
+		LineTo(200, 200).
+		Close()
+
+	clone := original.Clone()
+
+	// Clone should be independent
+	if clone == original {
+		t.Error("Clone should create a new path instance")
+	}
+
+	// Clone should have same commands
+	if len(clone.commands) != len(original.commands) {
+		t.Errorf("Clone: expected %d commands, got %d", len(original.commands), len(clone.commands))
+	}
+
+	for i := range original.commands {
+		if clone.commands[i].op != original.commands[i].op {
+			t.Errorf("Clone: command %d op mismatch", i)
+		}
+		if len(clone.commands[i].args) != len(original.commands[i].args) {
+			t.Errorf("Clone: command %d args length mismatch", i)
+		}
+	}
+
+	// Modifying clone should not affect original
+	// Need to call MoveTo first since the cloned path has no current point (was closed)
+	clone.MoveTo(300, 300).LineTo(400, 400)
+
+	if len(clone.commands) == len(original.commands) {
+		t.Error("Modifying clone should not affect original")
+	}
+}
+
+// Test toPDFOperators
+func TestPath_toPDFOperators(t *testing.T) {
+	tests := []struct {
+		name     string
+		build    func() *Path
+		expected []string // Expected operators
+	}{
+		{
+			name:     "empty path",
+			build:    func() *Path { return NewPath() },
+			expected: []string{},
+		},
+		{
+			name: "simple line",
+			build: func() *Path {
+				return NewPath().MoveTo(100, 100).LineTo(200, 200)
+			},
+			expected: []string{"100.00 100.00 m", "200.00 200.00 l"},
+		},
+		{
+			name: "closed triangle",
+			build: func() *Path {
+				return NewPath().
+					MoveTo(50, 50).
+					LineTo(150, 50).
+					LineTo(100, 150).
+					Close()
+			},
+			expected: []string{
+				"50.00 50.00 m",
+				"150.00 50.00 l",
+				"100.00 150.00 l",
+				"h",
+			},
+		},
+		{
+			name: "rectangle",
+			build: func() *Path {
+				return NewPath().AddRect(Rect{X: 10, Y: 20, Width: 100, Height: 50})
+			},
+			expected: []string{"10.00 20.00 100.00 50.00 re"},
+		},
+		{
+			name: "cubic bezier",
+			build: func() *Path {
+				return NewPath().
+					MoveTo(0, 0).
+					CubicTo(50, 0, 100, 100, 100, 50)
+			},
+			expected: []string{
+				"0.00 0.00 m",
+				"50.00 0.00 100.00 100.00 100.00 50.00 c",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := tt.build()
+			output := path.toPDFOperators()
+
+			if len(tt.expected) == 0 {
+				if output != "" {
+					t.Errorf("Expected empty output, got: %q", output)
+				}
+				return
+			}
+
+			// Check that all expected operators are present
+			for _, expected := range tt.expected {
+				if !strings.Contains(output, expected) {
+					t.Errorf("Expected output to contain %q, got:\n%s", expected, output)
+				}
+			}
+		})
+	}
+}
+
+// Test fluent API chaining
+func TestPath_FluentAPI(t *testing.T) {
+	// Test that all methods return *Path for chaining
+	path := NewPath().
+		MoveTo(0, 0).
+		LineTo(100, 0).
+		LineTo(100, 100).
+		CubicTo(150, 150, 50, 150, 0, 100).
+		QuadraticTo(50, 50, 0, 0).
+		Close().
+		AddRect(Rect{X: 200, Y: 200, Width: 50, Height: 50}).
+		AddCircle(Point{300, 300}, 25).
+		AddEllipse(Rect{X: 400, Y: 400, Width: 100, Height: 50})
+
+	if path == nil {
+		t.Error("Fluent API should return path for chaining")
+	}
+
+	if len(path.commands) == 0 {
+		t.Error("Fluent API chain should build path")
+	}
+}
+
+// Benchmark Path creation
+func BenchmarkPath_SimpleLine(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = NewPath().MoveTo(0, 0).LineTo(100, 100)
+	}
+}
+
+func BenchmarkPath_ComplexPath(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = NewPath().
+			MoveTo(0, 0).
+			LineTo(100, 0).
+			LineTo(100, 100).
+			CubicTo(150, 150, 50, 150, 0, 100).
+			QuadraticTo(50, 50, 0, 0).
+			Close()
+	}
+}
+
+func BenchmarkPath_AddCircle(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = NewPath().AddCircle(Point{150, 150}, 50)
+	}
+}
+
+func BenchmarkPath_AddRect(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = NewPath().AddRect(Rect{X: 0, Y: 0, Width: 100, Height: 100})
+	}
+}
+
+func BenchmarkPath_Clone(b *testing.B) {
+	path := NewPath().
+		MoveTo(0, 0).
+		LineTo(100, 0).
+		LineTo(100, 100).
+		LineTo(0, 100).
+		Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = path.Clone()
+	}
+}
+
+func BenchmarkPath_Bounds(b *testing.B) {
+	path := NewPath().
+		MoveTo(0, 0).
+		LineTo(100, 0).
+		LineTo(100, 100).
+		LineTo(0, 100).
+		Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = path.Bounds()
+	}
+}
+
+func BenchmarkPath_ToPDFOperators(b *testing.B) {
+	path := NewPath().
+		MoveTo(0, 0).
+		LineTo(100, 0).
+		LineTo(100, 100).
+		LineTo(0, 100).
+		Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = path.toPDFOperators()
+	}
+}


### PR DESCRIPTION
## Summary

Implements full **Path Builder API** for vector graphics with a fluent interface. This is **CRITICAL** for GoGPU/gg integration.

### API Features

**Path Construction:**
- `MoveTo(x, y)` - Start new subpath
- `LineTo(x, y)` - Append straight line
- `CubicTo(c1x, c1y, c2x, c2y, x, y)` - Cubic Bézier curve
- `QuadraticTo(cx, cy, x, y)` - Quadratic Bézier (converts to cubic)
- `Close()` - Close current subpath

**Shape Helpers:**
- `AddRect(rect)` - Rectangle
- `AddRoundedRect(rect, radius)` - Rounded rectangle
- `AddCircle(center, radius)` - Circle (4 Bézier curves)
- `AddEllipse(rect)` - Ellipse
- `AddArc(center, radius, startAngle, endAngle)` - Circular arc

**Path Operations:**
- `IsEmpty()` - Check if path has no commands
- `Bounds()` - Calculate bounding box
- `Clone()` - Deep copy

**Surface Integration:**
- `DrawPath(path)` - Draw with current fill + stroke
- `FillPath(path)` - Fill only
- `StrokePath(path)` - Stroke only

### Example Usage

```go
// Complex path with fluent API
path := NewPath().
    MoveTo(100, 100).
    LineTo(200, 100).
    QuadraticTo(250, 150, 200, 200).
    CubicTo(150, 250, 100, 250, 100, 200).
    Close()

surface.SetFill(NewFill(Red))
surface.SetStroke(NewStroke(Black).WithWidth(2))
surface.DrawPath(path)

// Shape shortcuts
circle := NewPath().AddCircle(Point{150, 150}, 50)
surface.FillPath(circle)
```

### Implementation Details

**QuadraticTo Conversion:**
- PDF doesn't support quadratic Bézier curves
- Automatically converts using standard algorithm:
  - `CP1 = P0 + 2/3 * (CP - P0)`
  - `CP2 = P1 + 2/3 * (CP - P1)`

**PDF Output:**
- Path commands map to PDF operators: `m`, `l`, `c`, `h`, `re`
- Optimized rectangle operator for `AddRect`
- Efficient arc approximation (max 90° segments)

### Testing

**Coverage:**
- 25+ unit tests
- Edge cases (panics, invalid inputs, empty paths)
- QuadraticTo conversion accuracy test
- PDF operator generation tests
- Fluent API chaining test
- 7 benchmarks

**Results:**
- All tests pass ✅
- Linter clean (0 issues) ✅
- go fmt clean ✅

### Files Changed

- `creator/path.go` (624 lines) - Full Path implementation
- `creator/path_test.go` (701 lines) - Comprehensive tests
- `creator/surface.go` (+116 lines) - DrawPath, FillPath, StrokePath

### GoGPU/gg Integration

This feature is **required** for GoGPU/gg PDF backend (see `GXPDF-GG-INTEGRATION.md` §3.1).

**gg API mapping:**
```go
// gg method → gxpdf method
dc.MoveTo(x, y)      → path.MoveTo(x, y)
dc.LineTo(x, y)      → path.LineTo(x, y)
dc.QuadraticTo(...)  → path.QuadraticTo(...)
dc.CubicTo(...)      → path.CubicTo(...)
dc.ClosePath()       → path.Close()
dc.Fill()            → surface.FillPath(path)
dc.Stroke()          → surface.StrokePath(path)
```

### Next Steps

After this PR:
- feat-051: Linear Gradient
- feat-052: Radial Gradient
- feat-053: ClipPath

---

🤖 Part of v0.2.0 "Graphics Revolution" milestone