### PR TITLE
feat: implement clipping path support (feat-053)

### DIFF
--- a/creator/graphics_state.go
+++ b/creator/graphics_state.go
@@ -19,6 +19,10 @@ type GraphicsState struct {
 	// Drawing operations are clipped to this path.
 	ClipPath *Path
 
+	// ClipRule is the fill rule for the clipping path.
+	// Only used when ClipPath is not nil.
+	ClipRule FillRule
+
 	// Fill is the current fill configuration.
 	Fill *Fill
 


### PR DESCRIPTION
## Summary

- Implement clipping path support for Surface API (feat-053)
- Required for GoGPU/gg integration (GXPDF-GG-INTEGRATION.md §3.4)

## Changes

- `PushClipPath(path *Path, rule FillRule)` on Surface
- Clip intersection with existing clip region
- Support for NonZero and EvenOdd fill rules
- PDF operators: W (non-zero), W* (even-odd), n (no-op paint)

## Test plan

- [x] `go fmt ./...`
- [x] `go vet ./...`
- [x] `go test ./creator/...`
- [x] `golangci-lint run`

🤖 Generated with [Claude Code](https://claude.ai/code)
