### PR TITLE
fix(parser): handle carriage return line endings in startxref parsing

### DIFF
--- a/internal/parser/reader.go
+++ b/internal/parser/reader.go
@@ -240,8 +240,12 @@ func (r *Reader) findStartXRef() (int64, error) {
 	}
 
 	// Parse the offset after "startxref"
-	// Format: startxref\n123\n%%EOF
+	// Format: startxref\n123\n%%EOF (or with \r line endings)
 	afterKeyword := content[idx+9:] // Skip "startxref"
+
+	// Normalize line endings: replace \r\n and \r with \n
+	afterKeyword = strings.ReplaceAll(afterKeyword, "\r\n", "\n")
+	afterKeyword = strings.ReplaceAll(afterKeyword, "\r", "\n")
 
 	// Find the number (skip whitespace)
 	lines := strings.Split(afterKeyword, "\n")


### PR DESCRIPTION
## Summary

Some PDFs use `\r` (carriage return) as line terminators instead of `\n` (line feed). The `findStartXRef()` function was splitting only on `\n`, causing parsing failures for such files.

## Problem

PDFs with carriage return line endings fail with:
```
invalid startxref format: expected offset after keyword
```

The startxref section looks like:
```
startxref\r
116\r
%%EOF\r
```

When splitting on `\n` only, the entire string becomes one "line", triggering the error.

## Solution

Normalize line endings before parsing by replacing `\r\n` and `\r` with `\n`:

```go
afterKeyword = strings.ReplaceAll(afterKeyword, "\r\n", "\n")
afterKeyword = strings.ReplaceAll(afterKeyword, "\r", "\n")
```

## Testing

- Tested against PDFs with `\r` line endings that previously failed
- All existing tests continue to pass
