### PR TITLE
  refactor: remove redundant min() helper

### DIFF
--- a/internal/tabledetect/column_boundary_detector.go
+++ b/internal/tabledetect/column_boundary_detector.go
@@ -729,13 +729,6 @@ func (cbd *ColumnBoundaryDetector) clusterPositions(positions []float64, epsilon
 	return clusters
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // detectBoundariesWhitespace implements whitespace-based column detection.
 //
 // This is the BEST PRACTICE approach based on recent research (2024-2025).


### PR DESCRIPTION
                                                                                                                                               
  ## Summary                                                                                                                                                              
                                                                                                                                                                          
  Remove custom `min()` helper function that is now redundant since Go 1.21+ includes `min()` as a builtin.                                                               
                                                                                                                                                                          
  ## Changes                                                                                                                                                              
                                                                                                                                                                          
  - Remove `min(a, b int) int` helper from `internal/tabledetect/column_boundary_detector.go`                                                                             
                                                                                                                                                                          
  ## Notes                                                                                                                                                                
                                                                                                                                                                          
  The project requires Go 1.25+ (per README), so the builtin `min()` is always available.      