### PR TITLE
 fix(parser): correct token position after parsing stream with indirect Length

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -427,10 +427,11 @@ func (p *Parser) parseStreamUntilEndstream(dict *Dictionary) (*Stream, error) {
 		}
 	}
 
-	// Update lexer state
+	// Update lexer state - skip whitespace and read the next token
+	// Unlike the normal stream parsing path (which reads "endstream" then advances to "endobj"),
+	// here we've already consumed "endstream" by scanning raw bytes, so NextToken reads "endobj" directly
 	p.lexer.skipWhitespace()
 	p.current, _ = p.lexer.NextToken()
-	_ = p.advance()
 
 	return NewStream(dict, content), nil
 }


### PR DESCRIPTION
## Summary
Fix parsing of streams including `ObjStm`  that use indirect `/Length` references (e.g., `/Length 57 0 R`).

## Problem
When a stream dictionary has an indirect reference for `/Length`, the parser falls back to `parseStreamUntilEndstream()` which scans raw bytes for the `endstream` keyword. After finding it, the function incorrectly called `p.advance()` after reading the next token, moving the parser one token past `endobj`.

This caused `ParseIndirectObject()` to fail with:

```
expected 'endobj' keyword, got INTEGER("57")
```

## Root Cause
In the normal stream parsing path, the parser reads "endstream" token, sets `p.current` to it, then advances to "endobj". But in `parseStreamUntilEndstream()`, `endstream` was already consumed by raw byte scanning, so `NextToken()` reads `endobj` directly. The extra `advance()` call then moved past `endobj` to the next object.

## Fix
Remove the erroneous `p.advance()` call from `parseStreamUntilEndstream()`, leaving `p.current` positioned at `endobj` as expected.

## Test plan
- [x] Existing tests pass
- [x] PDFs with `ObjStm` using indirect Length now parse correctly
