### PR TITLE
docs: update public documentation for v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-02-16 "Parser Hardening"
+
+### Added
+- **Logging Package** - slog-based configurable logging (#21)
+  - `logging.SetLogger()` / `logging.Logger()` API
+  - Silent by default, opt-in via `slog.Handler`
+  - All convenience methods (`ExtractText`, `ExtractTables`, `GetImages`) log errors via slog
+- **Image XObject Rendering** - Complete image rendering in Writer (#36, #37)
+  - `DrawImage()` and `DrawImageFit()` now produce visible images in PDFs
+  - JPEG support via `/Filter /DCTDecode`
+  - PNG support via `/Filter /FlateDecode` with `/SMask` for alpha channel
+  - Proper CTM transformation for positioning and scaling
+- **Watermark Rendering** - Writer now renders watermarks (#38)
+  - Text watermarks with rotation, opacity, and font support
+  - ExtGState for transparency
+- **Text Extraction Example** - Added to README
+
+### Fixed
+- **Error Propagation** - Public API no longer silently swallows errors (#35, #39)
+  - `ExtractTextFromPage()` now properly returns errors
+  - Convenience methods log errors via slog instead of discarding them
+  - `PageCount()`, `ExtractTables()`, `GetImages()` all log on failure
+- **Parser Robustness** - 9 parser fixes from community contributions (#21-#33)
+  - Leading whitespace before `%PDF-` header (#23)
+  - CR line endings in `startxref` (#25)
+  - Trailing garbage after `%%EOF` with progressive search (#27)
+  - CMap `uint16` infinite loop — DoS vulnerability fix (#28)
+  - Token position after indirect `Length` (#32)
+  - Progressive xref stream buffer 1KB→4KB (#30)
+  - `/W [0 0 0]` in xref streams (#31)
+  - PNG predictor support for xref streams — all 5 filter types (#24)
+  - Off-by-one xref object recovery with lenient parsing (#33)
+- **Redundant `min()` helper** - Removed in favor of Go 1.21+ builtin (#29)
+
+### Contributors
+- [@mikeschinkel](https://github.com/mikeschinkel) — 11 PRs merged (parser hardening, logging)
+
+---
+
 ## [0.2.1] - 2026-02-05
 
 ### Fixed
@@ -84,7 +123,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## Planned (v0.3.0+)
+## Planned (v0.4.0+)
+- Encrypted PDF reading (AES-128, empty password)
 - Digital signatures (sign and verify)
 - PDF/A compliance
 - Object streams (30% file size reduction)
@@ -194,7 +234,8 @@ Initial public release of GxPDF - a modern, enterprise-grade PDF library for Go.
 
 ---
 
-[Unreleased]: https://github.com/coregx/gxpdf/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/coregx/gxpdf/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/coregx/gxpdf/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/coregx/gxpdf/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/coregx/gxpdf/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/coregx/gxpdf/compare/v0.1.0...v0.1.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ This project follows a professional Code of Conduct. By participating, you agree
 
 ### Prerequisites
 
-- **Go 1.23+** (required)
+- **Go 1.25+** (required)
 - **Git**
 - **golangci-lint** (recommended)
 
@@ -330,7 +330,8 @@ Look for [`good first issue`](https://github.com/coregx/gxpdf/labels/good%20firs
 
 ### Areas That Need Help
 
-- Digital signatures (v0.3.0)
+- Encrypted PDF reading (v0.4.0)
+- Digital signatures (v0.4.0)
 - PDF/A compliance
 - Performance optimization
 - Documentation and examples

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Convenience methods like `ExtractText()`, `ExtractTables()`, and `GetImages()` l
 - [x] Watermarks
 - [x] Page operations (merge, split, rotate)
 
-### v0.2.0 "Graphics Revolution" (In Development)
+### v0.2.0 "Graphics Revolution" (Released)
 
 **Skia-like Graphics API** for [GoGPU/gg](https://github.com/gogpu/gg) integration:
 
@@ -331,7 +331,16 @@ Convenience methods like `ExtractText()`, `ExtractTables()`, and `GetImages()` l
 
 - [x] WASM API (WriteTo, Bytes for in-memory generation)
 
-### v0.3.0+ (Planned)
+### v0.3.0 "Parser Hardening" (Released)
+
+- [x] slog-based configurable logging
+- [x] Image XObject rendering (JPEG + PNG + alpha)
+- [x] Watermark rendering with rotation and opacity
+- [x] Error propagation in public API
+- [x] 11 parser robustness fixes (community contributions by @mikeschinkel)
+
+### v0.4.0+ (Planned)
+- [ ] Encrypted PDF reading
 - [ ] Digital signatures
 - [ ] PDF/A compliance
 - [ ] Object streams (30% compression)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,9 +2,35 @@
 
 Strategic development plan for the GxPDF PDF library.
 
-**Current Version**: v0.2.0 "Graphics Revolution"
+**Current Version**: v0.3.0 "Parser Hardening"
 
 ## Version History
+
+### v0.3.0 "Parser Hardening"
+
+**Released**: February 2026
+
+Major parser robustness improvements and rendering fixes:
+
+#### New: Logging Package
+- slog-based configurable logging (silent by default)
+- Error visibility for convenience methods (ExtractText, etc.)
+
+#### Image & Watermark Rendering (Writer)
+- Complete image XObject rendering (JPEG + PNG + alpha)
+- Watermark rendering with rotation and opacity
+- Fixes #36: DrawImage/DrawImageFit now work correctly
+
+#### Error Propagation
+- Public API methods properly return/log errors instead of silently failing
+- ExtractTextFromPage returns actual errors
+
+#### Parser Hardening (11 community PRs by @mikeschinkel)
+- Leading whitespace, CR line endings, trailing garbage after %%EOF
+- CMap uint16 infinite loop fix (DoS vulnerability)
+- PNG predictor support for xref streams (all 5 filter types)
+- Progressive xref stream buffer, /W [0 0 0] support
+- Off-by-one xref object recovery with lenient parsing
 
 ### v0.2.0 "Graphics Revolution"
 
@@ -52,15 +78,19 @@ Full-featured PDF library with:
 
 ## Planned Features
 
-### v0.3.0 - Digital Signatures & DX Improvements
+### v0.4.0 - Encryption Reading & Digital Signatures
 
 **Priority**: P2
+
+#### Encrypted PDF Reading
+- **Standard Security Handler** - V4/R4 AES-128 with empty password
+- **Key Derivation** - MD5/SHA-256 per PDF spec revision
+- **Stream/String Decryption** - AES-CBC before decompression
 
 #### Digital Signatures
 - **Sign PDFs** - Apply digital signatures with PKCS#12 certificates
 - **Verify Signatures** - Validate existing signatures
 - **Visible/Invisible** - Both signature types
-- **Timestamp Support** - TSA integration
 
 #### Developer Experience
 - **Fluent Text API** - Chainable text rendering
@@ -68,7 +98,7 @@ Full-featured PDF library with:
 - **Y-Cursor** - Automatic vertical positioning
 - **Simple Table API** - Easy table creation
 
-### v0.4.0 - PDF/A & Advanced Features
+### v0.5.0 - PDF/A & Advanced Features
 
 - **PDF/A-1b** - Basic archival compliance
 - **PDF/A-2b** - Extended archival compliance
@@ -76,7 +106,7 @@ Full-featured PDF library with:
 - **Invoice Template** - Pre-built invoice generation
 - **Chart Integration** - Embed charts in PDFs
 
-### v0.5.0 - Rendering & Optimization
+### v0.6.0 - Rendering & Optimization
 
 - **PDF Render** - Render PDF pages to images
 - **Barcode Generation** - QR codes, Code128, etc.
@@ -117,15 +147,22 @@ Full-featured PDF library with:
 | Form Filling | Done | v0.2.0 |
 | Form Flattening | Done | v0.2.0 |
 | WASM API | Done | v0.2.0 |
-| Digital Signatures | Planned | v0.3.0 |
-| Fluent Text API | Planned | v0.3.0 |
-| PDF/A Compliance | Planned | v0.4.0 |
-| PDF Render to Image | Planned | v0.5.0 |
+| Logging (slog) | Done | v0.3.0 |
+| Image XObject Rendering | Done | v0.3.0 |
+| Watermark Rendering | Done | v0.3.0 |
+| Error Propagation | Done | v0.3.0 |
+| Parser Hardening | Done | v0.3.0 |
+| Encrypted PDF Reading | Planned | v0.4.0 |
+| Digital Signatures | Planned | v0.4.0 |
+| Fluent Text API | Planned | v0.4.0 |
+| PDF/A Compliance | Planned | v0.5.0 |
+| PDF Render to Image | Planned | v0.6.0 |
 
-## Backlog (10 tasks)
+## Backlog (11 tasks)
 
 | ID | Feature | Priority | Description |
 |----|---------|----------|-------------|
+| feat-042 | Encrypted PDF Reading | **P2** | AES-128 with empty password |
 | feat-037 | Digital Signatures | **P2** | Sign and verify PDFs |
 | feat-062 | Fluent Text API | P3 | Chainable text methods |
 | feat-063 | Paragraph | P3 | Multi-line text container |


### PR DESCRIPTION
## Summary

Update all public documentation for the v0.3.0 "Parser Hardening" release.

### Changes

- **CHANGELOG.md** — Complete v0.3.0 section: logging package, image/watermark rendering, error propagation, 9 parser fixes, contributor credit
- **ROADMAP.md** — Current version updated to v0.3.0, feature status table expanded (logging, image rendering, watermark, error propagation, parser hardening), backlog updated with encrypted PDF reading, planned versions shifted (v0.4.0–v0.6.0)
- **CONTRIBUTING.md** — Go version updated from 1.23+ to 1.25+, "Areas That Need Help" updated with v0.4.0 references
- **README.md** — Roadmap section: v0.2.0 marked as Released, v0.3.0 section added, planned section shifted to v0.4.0+

### Checklist

- [x] `go fmt ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues
- [x] No code changes, documentation only
