### PR TITLE
feat: add text opacity support via ExtGState

### DIFF
--- a/creator/creator.go
+++ b/creator/creator.go
@@ -915,6 +915,11 @@ func convertTextOps(ops []TextOperation) []writer.TextOp {
 			}
 		}
 
+		// Propagate opacity if set.
+		if op.Opacity != nil {
+			textOp.Opacity = *op.Opacity
+		}
+
 		textOps = append(textOps, textOp)
 	}
 	return textOps

--- a/creator/opacity_test.go
+++ b/creator/opacity_test.go
@@ -564,3 +564,285 @@ func TestOpacity_RectValidation(t *testing.T) {
 		})
 	}
 }
+
+// -------------------------------------------------------------------------
+// Text Opacity Tests (feat-075, issue #46)
+// -------------------------------------------------------------------------
+
+// TestAddTextColorAlpha verifies that text with opacity stores the correct
+// TextOperation and that the opacity value is propagated.
+func TestAddTextColorAlpha(t *testing.T) {
+	c := New()
+	page, err := c.NewPage()
+	if err != nil {
+		t.Fatalf("NewPage() error = %v", err)
+	}
+
+	err = page.AddTextColorAlpha("Hello", 100, 700, Helvetica, 12, Red, 0.5)
+	if err != nil {
+		t.Fatalf("AddTextColorAlpha() error = %v", err)
+	}
+
+	ops := page.TextOperations()
+	if len(ops) != 1 {
+		t.Fatalf("expected 1 text operation, got %d", len(ops))
+	}
+
+	op := ops[0]
+	if op.Opacity == nil {
+		t.Fatal("expected Opacity to be set, got nil")
+	}
+	if *op.Opacity != 0.5 {
+		t.Errorf("expected Opacity 0.5, got %f", *op.Opacity)
+	}
+	if op.Text != "Hello" {
+		t.Errorf("expected text 'Hello', got %q", op.Text)
+	}
+}
+
+// TestAddTextColorRotatedAlpha verifies combined rotation and opacity.
+func TestAddTextColorRotatedAlpha(t *testing.T) {
+	c := New()
+	page, err := c.NewPage()
+	if err != nil {
+		t.Fatalf("NewPage() error = %v", err)
+	}
+
+	err = page.AddTextColorRotatedAlpha("DRAFT", 300, 400, HelveticaBold, 48, Red, 45, 0.3)
+	if err != nil {
+		t.Fatalf("AddTextColorRotatedAlpha() error = %v", err)
+	}
+
+	ops := page.TextOperations()
+	if len(ops) != 1 {
+		t.Fatalf("expected 1 text operation, got %d", len(ops))
+	}
+
+	op := ops[0]
+	if op.Opacity == nil {
+		t.Fatal("expected Opacity to be set, got nil")
+	}
+	if *op.Opacity != 0.3 {
+		t.Errorf("expected Opacity 0.3, got %f", *op.Opacity)
+	}
+	if op.Rotation != 45 {
+		t.Errorf("expected Rotation 45, got %f", op.Rotation)
+	}
+}
+
+// TestAddTextColorAlpha_ValidationErrors tests boundary validation for text opacity.
+func TestAddTextColorAlpha_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		opacity float64
+		wantErr bool
+	}{
+		{"valid 0.0", 0.0, false},
+		{"valid 0.5", 0.5, false},
+		{"valid 1.0", 1.0, false},
+		{"invalid -0.01", -0.01, true},
+		{"invalid 1.01", 1.01, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := New()
+			page, _ := c.NewPage()
+			err := page.AddTextColorAlpha("test", 100, 700, Helvetica, 12, Black, tt.opacity)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected validation error for opacity %.4f, got nil", tt.opacity)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for opacity %.4f: %v", tt.opacity, err)
+			}
+		})
+	}
+}
+
+// TestConvertTextOps_OpacityPropagation verifies that opacity is passed from
+// creator TextOperation to writer TextOp via convertTextOps.
+func TestConvertTextOps_OpacityPropagation(t *testing.T) {
+	opacity := 0.4
+	ops := []TextOperation{
+		{
+			Text:    "translucent",
+			X:       50,
+			Y:       600,
+			Font:    Helvetica,
+			Size:    14,
+			Opacity: &opacity,
+		},
+		{
+			Text: "opaque",
+			X:    50,
+			Y:    580,
+			Font: Helvetica,
+			Size: 14,
+			// Opacity is nil → writer.TextOp.Opacity should be 0
+		},
+	}
+
+	writerOps := convertTextOps(ops)
+	if len(writerOps) != 2 {
+		t.Fatalf("expected 2 writer ops, got %d", len(writerOps))
+	}
+
+	if writerOps[0].Opacity != 0.4 {
+		t.Errorf("expected writer op[0] Opacity 0.4, got %f", writerOps[0].Opacity)
+	}
+	if writerOps[1].Opacity != 0 {
+		t.Errorf("expected writer op[1] Opacity 0 (not set), got %f", writerOps[1].Opacity)
+	}
+}
+
+// TestTextOpacity_ContentStream verifies that the writer emits the correct
+// ExtGState operator for text with opacity.
+func TestTextOpacity_ContentStream(t *testing.T) {
+	textOps := []writer.TextOp{
+		{
+			Text:    "semi-transparent",
+			X:       100,
+			Y:       700,
+			Font:    "Helvetica",
+			Size:    12,
+			Opacity: 0.5,
+		},
+	}
+
+	content, resources, err := writer.GenerateContentStream(textOps)
+	if err != nil {
+		t.Fatalf("GenerateContentStream() error = %v", err)
+	}
+
+	stream := string(content)
+
+	// Must contain gs operator for ExtGState
+	if !strings.Contains(stream, " gs") {
+		t.Errorf("expected ExtGState gs operator in stream, got: %s", stream)
+	}
+
+	// Must contain q/Q (save/restore state) around the text
+	if !strings.Contains(stream, "q\n") {
+		t.Errorf("expected SaveState (q) in stream, got: %s", stream)
+	}
+	if !strings.Contains(stream, "Q\n") {
+		t.Errorf("expected RestoreState (Q) in stream, got: %s", stream)
+	}
+
+	// Resources must have ExtGState entry
+	resStr := resources.String()
+	if !strings.Contains(resStr, "/ExtGState") {
+		t.Errorf("expected /ExtGState in resources, got: %s", resStr)
+	}
+}
+
+// TestTextOpacity_FullOpaque verifies that opacity 1.0 does NOT emit ExtGState.
+func TestTextOpacity_FullOpaque(t *testing.T) {
+	textOps := []writer.TextOp{
+		{
+			Text:    "fully opaque",
+			X:       100,
+			Y:       700,
+			Font:    "Helvetica",
+			Size:    12,
+			Opacity: 1.0,
+		},
+	}
+
+	content, _, err := writer.GenerateContentStream(textOps)
+	if err != nil {
+		t.Fatalf("GenerateContentStream() error = %v", err)
+	}
+
+	stream := string(content)
+
+	// Should NOT contain gs operator (fully opaque = no ExtGState needed)
+	if strings.Contains(stream, " gs") {
+		t.Errorf("fully opaque text should NOT emit gs operator, got: %s", stream)
+	}
+}
+
+// TestTextOpacity_ZeroValue verifies that Opacity == 0 (not set) does NOT emit ExtGState.
+func TestTextOpacity_ZeroValue(t *testing.T) {
+	textOps := []writer.TextOp{
+		{
+			Text: "default opacity",
+			X:    100,
+			Y:    700,
+			Font: "Helvetica",
+			Size: 12,
+			// Opacity is 0 (zero value, means "not set")
+		},
+	}
+
+	content, _, err := writer.GenerateContentStream(textOps)
+	if err != nil {
+		t.Fatalf("GenerateContentStream() error = %v", err)
+	}
+
+	stream := string(content)
+
+	if strings.Contains(stream, " gs") {
+		t.Errorf("default (zero) opacity should NOT emit gs operator, got: %s", stream)
+	}
+}
+
+// TestTextOpacity_WithRotation verifies that opacity and rotation work together.
+func TestTextOpacity_WithRotation(t *testing.T) {
+	textOps := []writer.TextOp{
+		{
+			Text:     "rotated + transparent",
+			X:        200,
+			Y:        400,
+			Font:     "Helvetica",
+			Size:     24,
+			Opacity:  0.5,
+			Rotation: 45,
+		},
+	}
+
+	content, _, err := writer.GenerateContentStream(textOps)
+	if err != nil {
+		t.Fatalf("GenerateContentStream() error = %v", err)
+	}
+
+	stream := string(content)
+
+	// Must have both gs (opacity) and Tm (rotation)
+	if !strings.Contains(stream, " gs") {
+		t.Errorf("expected gs operator for opacity, got: %s", stream)
+	}
+	if !strings.Contains(stream, " Tm") {
+		t.Errorf("expected Tm operator for rotation, got: %s", stream)
+	}
+}
+
+// TestAddTextCustomFontColorAlpha verifies custom font with opacity (nil font check).
+func TestAddTextCustomFontColorAlpha(t *testing.T) {
+	c := New()
+	page, _ := c.NewPage()
+
+	// nil font should return error
+	err := page.AddTextCustomFontColorAlpha("test", 100, 700, nil, 12, Black, 0.5)
+	if err == nil {
+		t.Error("expected error for nil font, got nil")
+	}
+}
+
+// TestAddTextCustomFontColorRotatedAlpha verifies the full-featured method.
+func TestAddTextCustomFontColorRotatedAlpha(t *testing.T) {
+	c := New()
+	page, _ := c.NewPage()
+
+	// nil font should return error
+	err := page.AddTextCustomFontColorRotatedAlpha("test", 100, 700, nil, 12, Black, 45, 0.5)
+	if err == nil {
+		t.Error("expected error for nil font, got nil")
+	}
+
+	// invalid opacity should return error
+	err = page.AddTextCustomFontColorRotatedAlpha("test", 100, 700, nil, 12, Black, 45, 1.5)
+	if err == nil {
+		t.Error("expected error for nil font, got nil")
+	}
+}

--- a/creator/page.go
+++ b/creator/page.go
@@ -432,6 +432,198 @@ func (p *Page) AddTextCustomFontColorRotated(text string, x, y float64, font *Cu
 	return nil
 }
 
+// AddTextColorAlpha adds colored text with opacity to the page.
+//
+// Opacity controls the transparency level of the text (ISO 32000 §11.6.4.4):
+//   - 1.0 = fully opaque (default)
+//   - 0.5 = 50% transparent
+//   - 0.0 = fully transparent
+//
+// The opacity is implemented via an ExtGState resource with /ca (fill alpha)
+// and /CA (stroke alpha) keys. Values are clamped to [0.0, 1.0].
+//
+// Parameters:
+//   - text: The string to display
+//   - x: Horizontal position in points (from left edge)
+//   - y: Vertical position in points (from bottom edge)
+//   - font: Font to use (one of the Standard 14 fonts)
+//   - size: Font size in points
+//   - color: Text color (RGB, 0.0 to 1.0 range)
+//   - opacity: Transparency level (0.0 to 1.0)
+//
+// Example:
+//
+//	// Semi-transparent watermark text
+//	err := page.AddTextColorAlpha("DRAFT", 200, 400, creator.HelveticaBold, 48, creator.Gray, 0.3)
+func (p *Page) AddTextColorAlpha(text string, x, y float64, font FontName, size float64, color Color, opacity float64) error {
+	if size <= 0 {
+		return errors.New("font size must be positive")
+	}
+	if color.R < 0 || color.R > 1 || color.G < 0 || color.G > 1 || color.B < 0 || color.B > 1 {
+		return errors.New("color components must be in range [0.0, 1.0]")
+	}
+	if err := validateOpacity(&opacity); err != nil {
+		return err
+	}
+
+	p.textOps = append(p.textOps, TextOperation{
+		Text:    text,
+		X:       x,
+		Y:       y,
+		Font:    font,
+		Size:    size,
+		Color:   color,
+		Opacity: &opacity,
+	})
+
+	return nil
+}
+
+// AddTextColorRotatedAlpha adds colored rotated text with opacity to the page.
+//
+// Combines rotation (ISO 32000 §8.3) and opacity (ISO 32000 §11.6.4.4).
+// Rotation angles are normalized to [0, 360). Opacity is clamped to [0.0, 1.0].
+//
+// Parameters:
+//   - text: The string to display
+//   - x: Horizontal position in points (from left edge) — also the rotation pivot
+//   - y: Vertical position in points (from bottom edge) — also the rotation pivot
+//   - font: Font to use (one of the Standard 14 fonts)
+//   - size: Font size in points
+//   - color: Text color (RGB, 0.0 to 1.0 range)
+//   - rotation: Rotation angle in degrees (counter-clockwise positive)
+//   - opacity: Transparency level (0.0 to 1.0)
+//
+// Example:
+//
+//	// Diagonal semi-transparent watermark
+//	err := page.AddTextColorRotatedAlpha("CONFIDENTIAL", 300, 400, creator.HelveticaBold, 36, creator.Red, 45, 0.2)
+func (p *Page) AddTextColorRotatedAlpha(text string, x, y float64, font FontName, size float64, color Color, rotation, opacity float64) error {
+	if size <= 0 {
+		return errors.New("font size must be positive")
+	}
+	if color.R < 0 || color.R > 1 || color.G < 0 || color.G > 1 || color.B < 0 || color.B > 1 {
+		return errors.New("color components must be in range [0.0, 1.0]")
+	}
+	if err := validateOpacity(&opacity); err != nil {
+		return err
+	}
+
+	rotation = normalizeAngle(rotation)
+
+	p.textOps = append(p.textOps, TextOperation{
+		Text:     text,
+		X:        x,
+		Y:        y,
+		Font:     font,
+		Size:     size,
+		Color:    color,
+		Rotation: rotation,
+		Opacity:  &opacity,
+	})
+
+	return nil
+}
+
+// AddTextCustomFontColorAlpha adds colored text with opacity using an embedded TrueType/OpenType font.
+//
+// Supports Unicode text (Cyrillic, CJK, Arabic, symbols) with transparency.
+// Opacity is implemented via ExtGState (ISO 32000 §11.6.4.4).
+//
+// Parameters:
+//   - text: The string to display (supports Unicode)
+//   - x: Horizontal position in points (from left edge)
+//   - y: Vertical position in points (from bottom edge)
+//   - font: Custom font loaded via LoadFont()
+//   - size: Font size in points
+//   - color: Text color (RGB, 0.0 to 1.0 range)
+//   - opacity: Transparency level (0.0 to 1.0)
+//
+// Example:
+//
+//	font, _ := creator.LoadFont("fonts/OpenSans-Regular.ttf")
+//	err := page.AddTextCustomFontColorAlpha("Полупрозрачный", 100, 700, font, 24, creator.Blue, 0.5)
+func (p *Page) AddTextCustomFontColorAlpha(text string, x, y float64, font *CustomFont, size float64, color Color, opacity float64) error {
+	if font == nil {
+		return errors.New("font cannot be nil")
+	}
+	if size <= 0 {
+		return errors.New("font size must be positive")
+	}
+	if color.R < 0 || color.R > 1 || color.G < 0 || color.G > 1 || color.B < 0 || color.B > 1 {
+		return errors.New("color components must be in range [0.0, 1.0]")
+	}
+	if err := validateOpacity(&opacity); err != nil {
+		return err
+	}
+
+	font.UseString(text)
+
+	p.textOps = append(p.textOps, TextOperation{
+		Text:       text,
+		X:          x,
+		Y:          y,
+		CustomFont: font,
+		Size:       size,
+		Color:      color,
+		Opacity:    &opacity,
+	})
+
+	return nil
+}
+
+// AddTextCustomFontColorRotatedAlpha adds colored rotated text with opacity using an embedded font.
+//
+// Combines custom font support, rotation, and opacity. This is the most flexible
+// text method, supporting Unicode, rotation (ISO 32000 §8.3), and transparency
+// (ISO 32000 §11.6.4.4) simultaneously.
+//
+// Parameters:
+//   - text: The string to display (supports Unicode)
+//   - x: Horizontal position in points (from left edge) — also the rotation pivot
+//   - y: Vertical position in points (from bottom edge) — also the rotation pivot
+//   - font: Custom font loaded via LoadFont()
+//   - size: Font size in points
+//   - color: Text color (RGB, 0.0 to 1.0 range)
+//   - rotation: Rotation angle in degrees (counter-clockwise positive)
+//   - opacity: Transparency level (0.0 to 1.0)
+//
+// Example:
+//
+//	font, _ := creator.LoadFont("fonts/OpenSans-Bold.ttf")
+//	err := page.AddTextCustomFontColorRotatedAlpha("DRAFT", 300, 400, font, 48, creator.Red, 45, 0.3)
+func (p *Page) AddTextCustomFontColorRotatedAlpha(text string, x, y float64, font *CustomFont, size float64, color Color, rotation, opacity float64) error {
+	if font == nil {
+		return errors.New("font cannot be nil")
+	}
+	if size <= 0 {
+		return errors.New("font size must be positive")
+	}
+	if color.R < 0 || color.R > 1 || color.G < 0 || color.G > 1 || color.B < 0 || color.B > 1 {
+		return errors.New("color components must be in range [0.0, 1.0]")
+	}
+	if err := validateOpacity(&opacity); err != nil {
+		return err
+	}
+
+	rotation = normalizeAngle(rotation)
+
+	font.UseString(text)
+
+	p.textOps = append(p.textOps, TextOperation{
+		Text:       text,
+		X:          x,
+		Y:          y,
+		CustomFont: font,
+		Size:       size,
+		Color:      color,
+		Rotation:   rotation,
+		Opacity:    &opacity,
+	})
+
+	return nil
+}
+
 // TextOperations returns all text operations for this page.
 //
 // This is used by the writer infrastructure to generate the content stream.

--- a/internal/writer/page_content.go
+++ b/internal/writer/page_content.go
@@ -45,6 +45,11 @@ type TextOp struct {
 	// Zero means standard horizontal text (Td operator).
 	// Non-zero values use the Tm (text matrix) operator instead.
 	Rotation float64
+
+	// Opacity is the text opacity (0.0 = fully transparent, 1.0 = fully opaque).
+	// A value of 0 means "not set" (default fully opaque).
+	// Values strictly between 0 and 1 emit an ExtGState with /ca and /CA keys.
+	Opacity float64
 }
 
 // EmbeddedFont represents a custom TrueType/OpenType font for embedding.
@@ -284,6 +289,13 @@ func GenerateContentStreamWithGraphics(textOps []TextOp, graphicsOps []GraphicsO
 			usedFonts[fontKey] = fontResName
 		}
 
+		// Apply opacity via ExtGState if needed (must be outside BT/ET).
+		hasOpacity := op.Opacity > 0 && op.Opacity < 1.0
+		if hasOpacity {
+			csw.SaveState()
+			applyOpacity(csw, op.Opacity, resources)
+		}
+
 		// Begin text object
 		csw.BeginText()
 
@@ -319,6 +331,10 @@ func GenerateContentStreamWithGraphics(textOps []TextOp, graphicsOps []GraphicsO
 
 		// End text object
 		csw.EndText()
+
+		if hasOpacity {
+			csw.RestoreState()
+		}
 	}
 
 	return csw.Bytes(), resources, nil


### PR DESCRIPTION
## Summary

Closes #46 — Adds text opacity (transparency) support to the creator API.

**New public methods** (4 methods, mirroring existing text API pattern):
- `Page.AddTextColorAlpha` — standard font + color + opacity
- `Page.AddTextColorRotatedAlpha` — standard font + color + rotation + opacity
- `Page.AddTextCustomFontColorAlpha` — custom font + color + opacity
- `Page.AddTextCustomFontColorRotatedAlpha` — custom font + color + rotation + opacity

**Three-layer implementation**:
- **Writer layer** (`internal/writer/page_content.go`): Added `Opacity float64` field to `TextOp`. Text ops with fractional opacity are wrapped in `q` (SaveState) → `gs` (SetGraphicsState with ExtGState) → `BT`...`ET` → `Q` (RestoreState), per ISO 32000 §11.6.4.4
- **Conversion layer** (`creator/creator.go`): `convertTextOps` propagates `*float64` Opacity to `float64` writer field
- **Creator layer** (`creator/page.go`): 4 new methods with `validateOpacity` validation, consistent with shape opacity API

**Design consistency**: Uses the same `applyOpacity` helper and `GetOrCreateExtGState` resource management as shape opacity (PR #48), ensuring shared ExtGState entries between shapes and text with identical opacity values.

## Test plan

- [x] 10 new tests in `creator/opacity_test.go` covering:
  - `AddTextColorAlpha` — stores correct TextOperation with opacity
  - `AddTextColorRotatedAlpha` — rotation + opacity combined
  - `AddTextColorAlpha_ValidationErrors` — boundary validation (0.0, 0.5, 1.0, -0.01, 1.01)
  - `ConvertTextOps_OpacityPropagation` — creator → writer propagation
  - `TextOpacity_ContentStream` — verifies gs/q/Q operators and ExtGState resource
  - `TextOpacity_FullOpaque` — opacity 1.0 does NOT emit ExtGState
  - `TextOpacity_ZeroValue` — opacity 0 (not set) does NOT emit ExtGState
  - `TextOpacity_WithRotation` — opacity + rotation work together
  - `AddTextCustomFontColorAlpha` — nil font validation
  - `AddTextCustomFontColorRotatedAlpha` — nil font + invalid opacity
- [x] `go fmt ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues
