### PR TITLE
docs: update public documentation for v0.5.0 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0] - Unreleased "Creator API"
+## [0.5.0] - Unreleased "Opacity & Bezier"
+
+### Added
+- **Text Opacity** - New `AddTextColorAlpha`, `AddTextColorRotatedAlpha`, `AddTextCustomFontColorAlpha`, `AddTextCustomFontColorRotatedAlpha` methods (#46)
+  - ExtGState transparency via `/ca` and `/CA` keys per ISO 32000 §11.6.4.4
+  - Works with both standard 14 fonts and custom TTF/OTF fonts
+  - Combines with rotation for watermark-style effects
+- **Quadratic Bezier Curves** - `DrawQuadBezierCurve` with `QuadBezierSegment` struct (#45)
+  - Exact degree elevation to cubic Bezier (not approximation)
+  - `QuadBezierSegment.ToCubic()` for manual conversion
+  - Multi-segment paths with full styling (stroke, fill, dash, opacity, gradient)
+
+### Fixed
+- **Shape Opacity** - `Opacity` on shape option structs now works correctly (#47)
+  - Root cause: 3-layer pipeline gap — opacity accepted by creator but dropped during conversion
+  - Fix propagates opacity through `convertOptions` → `writer.GraphicsOp` → ExtGState `gs` operator
+  - Affects all shape types: circles, ellipses, rectangles, polygons, polylines, lines, Bezier curves
+
+---
+
+## [0.4.0] - 2026-02-21 "Creator API"
 
 ### Added
 - **35+ Page Sizes** - Expanded from 8 to 38 built-in page sizes

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ### PDF Creation (Creator API)
 - **Text & Typography** - Rich text with multiple fonts, styles, and colors
-- **Graphics** - Lines, rectangles, circles, polygons, ellipses, Bezier curves
+- **Graphics** - Lines, rectangles, circles, polygons, ellipses, cubic and quadratic Bezier curves
 - **Gradients** - Linear and radial gradient fills
 - **Color Spaces** - RGB and CMYK support
 - **Tables** - Complex tables with merged cells, borders, backgrounds
@@ -31,6 +31,7 @@
 - **Custom Dimensions** - Arbitrary page sizes with unit conversion helpers (inches, mm, cm)
 - **Landscape/Portrait** - True landscape via `NewPageWithSize(A4, Landscape)` — industry-standard swapped-MediaBox
 - **Text Rotation** - Rotated text at any angle via `Tm` operator (standard 14 + custom TTF fonts)
+- **Opacity/Transparency** - Text and shape opacity via ExtGState (`AddTextColorAlpha`, shape `Opacity` option)
 - **Page Operations** - Merge, split, rotate, append
 
 ### PDF Reading & Extraction

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Strategic development plan for the GxPDF PDF library.
 
-**Current Version**: v0.3.0 "Parser Hardening"
+**Current Version**: v0.4.0 "Creator API"
 
 ## Version History
 
@@ -76,18 +76,14 @@ Full-featured PDF library with:
 - Multiple export formats
 - DDD architecture
 
-## Current Development
-
 ### v0.4.0 "Creator API"
 
-**Status**: In Development
+**Released**: February 2026
+
+Page sizes, custom dimensions, landscape orientation, and text rotation:
 
 #### 35+ Built-in Page Sizes
-- **ISO A series** (A0–A8), **B series** (B0–B6), **C/DL envelopes**
-- **ANSI engineering** (C, D, E), **US sizes** (Letter, Legal, Tabloid, Executive, Half Letter)
-- **Photo** (4×6, 5×7, 8×10), **Book publishing** (Digest, US Trade Book)
-- **Presentation slides** (16:9, 4:3) — PowerPoint/Keynote defaults
-- **JIS B series** (B4, B5), **US #10 envelope**
+- ISO A/B/C, ANSI, photo, book, JIS, envelopes, slides
 - Map-based architecture for maintainability
 
 #### Custom Page Dimensions (#41)
@@ -95,17 +91,33 @@ Full-featured PDF library with:
 - Unit conversion helpers: `InchesToPoints`, `MMToPoints`, `CMToPoints` + reverse
 
 #### Landscape Orientation (#41)
-- `NewPageWithSize(size, Landscape)` — industry-standard approach
-- True landscape via swapped MediaBox (no `/Rotate`)
+- `NewPageWithSize(size, Landscape)` — industry-standard swapped-MediaBox
 
 #### Text Rotation (#42)
-- `AddTextRotated` / `AddTextColorRotated` — standard 14 fonts
-- `AddTextCustomFontRotated` / `AddTextCustomFontColorRotated` — TTF/OTF fonts
-- Uses PDF `Tm` operator per ISO 32000 §9.4.2
+- `AddTextRotated` / `AddTextColorRotated` — standard 14 + custom TTF/OTF fonts
+- Angle normalization to [0, 360)
+
+## Current Development
+
+### v0.5.0 "Opacity & Bezier"
+
+**Status**: All tasks merged, awaiting release
+
+#### Shape Opacity Fix (#47)
+- Fixed 3-layer pipeline gap: opacity now propagated through writer
+- Affects all shape types (circles, ellipses, rectangles, polygons, etc.)
+
+#### Quadratic Bezier Curves (#45)
+- `DrawQuadBezierCurve` with `QuadBezierSegment` struct
+- Exact degree elevation to cubic (not approximation)
+
+#### Text Opacity (#46)
+- `AddTextColorAlpha`, `AddTextColorRotatedAlpha` + custom font variants
+- ExtGState transparency via `/ca` and `/CA` keys
 
 ## Planned Features
 
-### v0.5.0 - Encryption Reading & Digital Signatures
+### v0.6.0 - Encryption Reading & Digital Signatures
 
 **Priority**: P2
 
@@ -125,7 +137,7 @@ Full-featured PDF library with:
 - **Y-Cursor** - Automatic vertical positioning
 - **Simple Table API** - Easy table creation
 
-### v0.6.0 - PDF/A & Advanced Features
+### v0.7.0 - PDF/A & Advanced Features
 
 - **PDF/A-1b** - Basic archival compliance
 - **PDF/A-2b** - Extended archival compliance
@@ -133,7 +145,7 @@ Full-featured PDF library with:
 - **Invoice Template** - Pre-built invoice generation
 - **Chart Integration** - Embed charts in PDFs
 
-### v0.7.0 - Rendering & Optimization
+### v0.8.0 - Rendering & Optimization
 
 - **PDF Render** - Render PDF pages to images
 - **Barcode Generation** - QR codes, Code128, etc.
@@ -183,19 +195,25 @@ Full-featured PDF library with:
 | Custom Page Dimensions | Done | v0.4.0 |
 | Landscape/Portrait | Done | v0.4.0 |
 | Text Rotation | Done | v0.4.0 |
-| Encrypted PDF Reading | Planned | v0.5.0 |
-| Digital Signatures | Planned | v0.5.0 |
-| Fluent Text API | Planned | v0.5.0 |
-| PDF/A Compliance | Planned | v0.6.0 |
-| PDF Render to Image | Planned | v0.7.0 |
+| Shape Opacity | Done | v0.5.0 |
+| Quadratic Bezier Curves | Done | v0.5.0 |
+| Text Opacity | Done | v0.5.0 |
+| Encrypted PDF Reading | Planned | v0.6.0 |
+| Digital Signatures | Planned | v0.6.0 |
+| Fluent Text API | Planned | v0.6.0 |
+| PDF/A Compliance | Planned | v0.7.0 |
+| PDF Render to Image | Planned | v0.8.0 |
 
-## Backlog (11 tasks)
+## Backlog
 
 | ID | Feature | Priority | Status | Description |
 |----|---------|----------|--------|-------------|
 | feat-067 | Custom Page Dimensions | **P1** | **Done** | Arbitrary page sizes (#41) |
 | feat-068 | Text Rotation | **P1** | **Done** | Rotated text via Tm operator (#42) |
 | feat-069 | Paper Sizes Expansion | **P1** | **Done** | 35+ built-in page sizes |
+| fix-006 | Shape Opacity | **P1** | **Done** | Pipeline gap fix (#47) |
+| feat-074 | Quadratic Bezier | **P2** | **Done** | Degree elevation to cubic (#45) |
+| feat-075 | Text Opacity | **P2** | **Done** | ExtGState transparency (#46) |
 | feat-042 | Encrypted PDF Reading | **P2** | Backlog | AES-128 with empty password |
 | feat-037 | Digital Signatures | **P2** | Backlog | Sign and verify PDFs |
 | feat-062 | Fluent Text API | P3 | Backlog | Chainable text methods |


### PR DESCRIPTION
## Summary

Update public documentation to reflect v0.5.0 features (shape opacity fix, quadratic Bezier curves, text opacity).

- **CHANGELOG.md**: Add v0.5.0 section with all 3 changes, mark v0.4.0 as released (2026-02-21)
- **README.md**: Add opacity/transparency and quadratic Bezier to feature list
- **ROADMAP.md**: Add v0.5.0 "Opacity & Bezier" section, mark v0.4.0 released, shift encryption/signatures to v0.6.0

## Test plan

- [x] Documentation only — no code changes
