### PR TITLE
docs: update version references for v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,11 +169,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## Planned (v0.4.0+)
-- Encrypted PDF reading (AES-128, empty password)
+## Planned (v0.6.0+)
+- Encrypted PDF reading (AES-128, RC4-128, user password)
 - Digital signatures (sign and verify)
 - PDF/A compliance
-- Object streams (30% file size reduction)
 
 ---
 
@@ -280,7 +279,8 @@ Initial public release of GxPDF - a modern, enterprise-grade PDF library for Go.
 
 ---
 
-[Unreleased]: https://github.com/coregx/gxpdf/compare/v0.3.0...HEAD
+[0.5.0]: https://github.com/coregx/gxpdf/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/coregx/gxpdf/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/coregx/gxpdf/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/coregx/gxpdf/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/coregx/gxpdf/compare/v0.1.1...v0.2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,8 +330,8 @@ Look for [`good first issue`](https://github.com/coregx/gxpdf/labels/good%20firs
 
 ### Areas That Need Help
 
-- Encrypted PDF reading (v0.4.0)
-- Digital signatures (v0.4.0)
+- Encrypted PDF reading (v0.6.0)
+- Digital signatures (v0.6.0)
 - PDF/A compliance
 - Performance optimization
 - Documentation and examples

--- a/README.md
+++ b/README.md
@@ -344,18 +344,23 @@ Convenience methods like `ExtractText()`, `ExtractTables()`, and `GetImages()` l
 - [x] Error propagation in public API
 - [x] 11 parser robustness fixes (community contributions by @mikeschinkel)
 
-### v0.4.0 "Creator API" (In Development)
+### v0.4.0 "Creator API" (Released)
 
 - [x] 35+ built-in page sizes (ISO A/B/C, ANSI, photo, book, JIS, envelopes, slides)
 - [x] Custom page dimensions with unit conversions
 - [x] Landscape/Portrait orientation support
 - [x] Text rotation (AddTextRotated, AddTextColorRotated)
 
-### v0.5.0+ (Planned)
+### v0.5.0 "Opacity & Bezier" (Released)
+
+- [x] Shape opacity fix (all shape types)
+- [x] Text opacity (AddTextColorAlpha + custom font variants)
+- [x] Quadratic Bezier curves (DrawQuadBezierCurve)
+
+### v0.6.0+ (Planned)
 - [ ] Encrypted PDF reading
 - [ ] Digital signatures
 - [ ] PDF/A compliance
-- [ ] Object streams (30% compression)
 - [ ] SVG import
 
 ## License


### PR DESCRIPTION
## Summary

- Update stale version references across public documentation for v0.5.0 release
- CHANGELOG: fix Planned section (v0.4.0+ → v0.6.0+), add missing compare links for v0.4.0 and v0.5.0
- README: mark v0.4.0 as Released, add v0.5.0 "Opacity & Bezier" Released section, update Planned to v0.6.0+
- CONTRIBUTING: update encryption/signatures target from v0.4.0 to v0.6.0

## Test plan

- [ ] No code changes — documentation only
- [ ] CI passes (lint, vet, test)
