### PR TITLE
docs: set v0.5.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - Unreleased "Opacity & Bezier"
+## [0.5.0] - 2026-02-23 "Opacity & Bezier"
 
 ### Added
 - **Text Opacity** - New `AddTextColorAlpha`, `AddTextColorRotatedAlpha`, `AddTextCustomFontColorAlpha`, `AddTextCustomFontColorRotatedAlpha` methods (#46)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Strategic development plan for the GxPDF PDF library.
 
-**Current Version**: v0.4.0 "Creator API"
+**Current Version**: v0.5.0 "Opacity & Bezier"
 
 ## Version History
 
@@ -101,7 +101,7 @@ Page sizes, custom dimensions, landscape orientation, and text rotation:
 
 ### v0.5.0 "Opacity & Bezier"
 
-**Status**: All tasks merged, awaiting release
+**Released**: February 2026
 
 #### Shape Opacity Fix (#47)
 - Fixed 3-layer pipeline gap: opacity now propagated through writer


### PR DESCRIPTION
## Summary

- Set v0.5.0 release date to 2026-02-23 in CHANGELOG
- Update ROADMAP current version from v0.4.0 to v0.5.0
- Mark v0.5.0 as Released in ROADMAP

## Test plan

- [ ] No code changes — documentation only
- [ ] CI passes
