### PR TITLE
fix: create ExtGState objects for shape and text opacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-02-23
+
+### Fixed
+- **ExtGState Object Creation** - Shape and text opacity now produce valid PDF output (#46, #47)
+  - Root cause: ExtGState entries were registered in resource dictionary with placeholder object number `0`, but actual PDF indirect objects were never created — `/GS1 0 0 R` pointed to xref free entry
+  - Fix adds STEP 3.6 in writer pipeline: `createExtGStateObjects()` materializes `<< /Type /ExtGState /ca {opacity} /CA {opacity} >>` dictionaries with real object numbers
+  - Both page creation paths fixed: text-only (`createPageWithContent`) and graphics+text (`createPageWithAllContent`)
+  - Added slog debug logging for ExtGState object creation
+
+---
+
 ## [0.5.0] - 2026-02-23 "Opacity & Bezier"
 
 ### Added
@@ -279,6 +290,7 @@ Initial public release of GxPDF - a modern, enterprise-grade PDF library for Go.
 
 ---
 
+[0.5.1]: https://github.com/coregx/gxpdf/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/coregx/gxpdf/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/coregx/gxpdf/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/coregx/gxpdf/compare/v0.2.1...v0.3.0

--- a/README.md
+++ b/README.md
@@ -300,68 +300,7 @@ Convenience methods like `ExtractText()`, `ExtractTables()`, and `GetImages()` l
 
 ## Roadmap
 
-### v0.1.x (Stable)
-- [x] PDF reading and parsing (PDF 1.0-2.0)
-- [x] Text extraction with positions
-- [x] Table extraction (100% accuracy)
-- [x] CSV/JSON/Excel export
-- [x] Creator API (text, graphics, tables)
-- [x] JPEG/PNG image support
-- [x] TTF/OTF font embedding with full Unicode
-- [x] RC4/AES encryption
-- [x] Chapters and TOC
-- [x] Annotations
-- [x] Interactive forms (AcroForm)
-- [x] Watermarks
-- [x] Page operations (merge, split, rotate)
-
-### v0.2.0 "Graphics Revolution" (Released)
-
-**Skia-like Graphics API** for [GoGPU/gg](https://github.com/gogpu/gg) integration:
-
-- [x] Alpha channel / transparency (ExtGState)
-- [x] Push/Pop graphics state stack
-- [x] Fill/Stroke separation with Paint interface
-- [x] Path Builder API (MoveTo, LineTo, CubicTo, etc.)
-- [x] Linear and Radial gradients
-- [x] ClipPath support
-
-**Forms API** (Read, Fill, Flatten):
-
-- [x] Form field reader (GetFormFields, GetFieldValue)
-- [x] Form field writer (SetFieldValue with validation)
-- [x] Form flattening (FlattenForm, FlattenFields)
-
-**WASM/Platform Support**:
-
-- [x] WASM API (WriteTo, Bytes for in-memory generation)
-
-### v0.3.0 "Parser Hardening" (Released)
-
-- [x] slog-based configurable logging
-- [x] Image XObject rendering (JPEG + PNG + alpha)
-- [x] Watermark rendering with rotation and opacity
-- [x] Error propagation in public API
-- [x] 11 parser robustness fixes (community contributions by @mikeschinkel)
-
-### v0.4.0 "Creator API" (Released)
-
-- [x] 35+ built-in page sizes (ISO A/B/C, ANSI, photo, book, JIS, envelopes, slides)
-- [x] Custom page dimensions with unit conversions
-- [x] Landscape/Portrait orientation support
-- [x] Text rotation (AddTextRotated, AddTextColorRotated)
-
-### v0.5.0 "Opacity & Bezier" (Released)
-
-- [x] Shape opacity fix (all shape types)
-- [x] Text opacity (AddTextColorAlpha + custom font variants)
-- [x] Quadratic Bezier curves (DrawQuadBezierCurve)
-
-### v0.6.0+ (Planned)
-- [ ] Encrypted PDF reading
-- [ ] Digital signatures
-- [ ] PDF/A compliance
-- [ ] SVG import
+See [ROADMAP.md](ROADMAP.md) for the full development plan and version history.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Strategic development plan for the GxPDF PDF library.
 
-**Current Version**: v0.5.0 "Opacity & Bezier"
+**Current Version**: See [CHANGELOG.md](CHANGELOG.md)
 
 ## Version History
 

--- a/creator/opacity_test.go
+++ b/creator/opacity_test.go
@@ -180,6 +180,16 @@ func TestOpacity_WritesValidPDF(t *testing.T) {
 	if !strings.Contains(pdfStr, "/ExtGState") {
 		t.Error("PDF does not contain /ExtGState — opacity was not applied")
 	}
+
+	// Verify ExtGState references real objects (not placeholder 0 0 R).
+	if strings.Contains(pdfStr, "/GS1 0 0 R") {
+		t.Error("ExtGState /GS1 references object 0 — object was never created")
+	}
+
+	// Verify actual ExtGState dictionary exists in PDF.
+	if !strings.Contains(pdfStr, "/ca ") {
+		t.Error("PDF does not contain ExtGState dictionary with /ca opacity key")
+	}
 }
 
 // TestOpacity_ExtGStateSharing verifies that two shapes with the same opacity
@@ -734,6 +744,13 @@ func TestTextOpacity_ContentStream(t *testing.T) {
 	if !strings.Contains(resStr, "/ExtGState") {
 		t.Errorf("expected /ExtGState in resources, got: %s", resStr)
 	}
+
+	// Before object creation, ExtGState should have placeholder object number 0.
+	// This is expected — the writer layer creates the real objects later.
+	// Verify the entry exists in the resource dictionary.
+	if !strings.Contains(resStr, "/GS1") {
+		t.Errorf("expected /GS1 in resources, got: %s", resStr)
+	}
 }
 
 // TestTextOpacity_FullOpaque verifies that opacity 1.0 does NOT emit ExtGState.
@@ -844,5 +861,93 @@ func TestAddTextCustomFontColorRotatedAlpha(t *testing.T) {
 	err = page.AddTextCustomFontColorRotatedAlpha("test", 100, 700, nil, 12, Black, 45, 1.5)
 	if err == nil {
 		t.Error("expected error for nil font, got nil")
+	}
+}
+
+// -------------------------------------------------------------------------
+// TestOpacity_ExtGStateObjectCreated — end-to-end: verify that ExtGState
+// objects are actually created as PDF indirect objects with correct content.
+// -------------------------------------------------------------------------
+
+// TestOpacity_ExtGStateObjectCreated creates a document with a semi-transparent
+// circle and verifies that the resulting PDF contains:
+// 1. /GS1 references a real object (not 0 0 R)
+// 2. An ExtGState dictionary with /ca and /CA keys exists
+// 3. The opacity value is correct
+func TestOpacity_ExtGStateObjectCreated(t *testing.T) {
+	c := New()
+	page, err := c.NewPage()
+	if err != nil {
+		t.Fatalf("NewPage() error = %v", err)
+	}
+
+	opacity := 0.5
+	if err := page.DrawCircle(300, 400, 50, &CircleOptions{
+		FillColor: &Blue,
+		Opacity:   &opacity,
+	}); err != nil {
+		t.Fatalf("DrawCircle() error = %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := c.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo() error = %v", err)
+	}
+
+	pdfStr := string(buf.Bytes())
+
+	// /GS1 must NOT reference object 0.
+	if strings.Contains(pdfStr, "/GS1 0 0 R") {
+		t.Error("ExtGState /GS1 references object 0 — ExtGState object was never created")
+	}
+
+	// The actual ExtGState dictionary must exist somewhere in the PDF.
+	if !strings.Contains(pdfStr, "/Type /ExtGState") {
+		t.Error("PDF does not contain /Type /ExtGState dictionary")
+	}
+
+	// Must contain both /ca and /CA opacity keys.
+	if !strings.Contains(pdfStr, "/ca 0.50") {
+		t.Errorf("PDF does not contain /ca 0.50 for fill opacity")
+	}
+	if !strings.Contains(pdfStr, "/CA 0.50") {
+		t.Errorf("PDF does not contain /CA 0.50 for stroke opacity")
+	}
+}
+
+// TestTextOpacity_ExtGStateObjectCreated verifies end-to-end that text with
+// opacity produces a real ExtGState object in the final PDF.
+func TestTextOpacity_ExtGStateObjectCreated(t *testing.T) {
+	c := New()
+	page, err := c.NewPage()
+	if err != nil {
+		t.Fatalf("NewPage() error = %v", err)
+	}
+
+	err = page.AddTextColorAlpha("Translucent", 100, 700, Helvetica, 14, Red, 0.3)
+	if err != nil {
+		t.Fatalf("AddTextColorAlpha() error = %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := c.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo() error = %v", err)
+	}
+
+	pdfStr := string(buf.Bytes())
+
+	// /GS1 must NOT reference object 0.
+	if strings.Contains(pdfStr, "/GS1 0 0 R") {
+		t.Error("ExtGState /GS1 references object 0 — ExtGState object was never created")
+	}
+
+	// The actual ExtGState dictionary must exist.
+	if !strings.Contains(pdfStr, "/Type /ExtGState") {
+		t.Error("PDF does not contain /Type /ExtGState dictionary")
+	}
+
+	// Must contain the correct opacity value.
+	if !strings.Contains(pdfStr, "/ca 0.30") {
+		t.Errorf("PDF does not contain /ca 0.30 for fill opacity")
 	}
 }

--- a/internal/writer/pages.go
+++ b/internal/writer/pages.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/coregx/gxpdf/internal/document"
+	"github.com/coregx/gxpdf/logging"
 )
 
 // hasTextBlockOps checks if any graphics operations contain TextBlock (type 22).
@@ -264,6 +265,10 @@ func (w *PdfWriter) createPageWithContent(
 			}
 		}
 
+		// Create ExtGState objects for opacity and assign object numbers.
+		gsObjs := w.createExtGStateObjects(resources)
+		fontObjs = append(fontObjs, gsObjs...)
+
 		// Write resources dictionary
 		pageDict.WriteString(" /Resources ")
 		pageDict.Write(resources.Bytes())
@@ -397,12 +402,14 @@ func (w *PdfWriter) createPageWithAllContent(
 		// STEP 3.5: Create image XObjects for image operations and assign object numbers.
 		imageObjs, err := w.createAndAssignImageXObjects(graphicsOps, resources)
 		if err != nil {
-			// Log error but continue - don't fail the whole page
-			// TODO: Add logging when available
-			_ = err
+			logging.Logger().Warn("failed to create image XObjects", "error", err)
 		} else {
 			fontObjs = append(fontObjs, imageObjs...)
 		}
+
+		// STEP 3.6: Create ExtGState objects for opacity and assign object numbers.
+		gsObjs := w.createExtGStateObjects(resources)
+		fontObjs = append(fontObjs, gsObjs...)
 
 		// Write resources dictionary
 		pageDict.WriteString(" /Resources ")
@@ -450,6 +457,48 @@ func (w *PdfWriter) createPageWithAllContent(
 func (w *PdfWriter) createPage(page *document.Page, objNum int, parentRef int) *IndirectObject {
 	pageObj, _, _ := w.createPageWithContent(page, objNum, parentRef, nil)
 	return pageObj
+}
+
+// createExtGStateObjects creates ExtGState PDF indirect objects for all registered graphics states
+// in the resource dictionary and assigns their object numbers.
+//
+// This fills the gap where ExtGState entries were registered during content stream generation
+// (with placeholder object number 0) but never materialized as actual PDF objects.
+//
+// Each ExtGState dictionary has the format:
+//
+//	<< /Type /ExtGState /ca {opacity} /CA {opacity} >>
+//
+// where /ca controls fill opacity and /CA controls stroke opacity.
+//
+// Returns the created IndirectObject slice.
+func (w *PdfWriter) createExtGStateObjects(resources *ResourceDictionary) []*IndirectObject {
+	entries := resources.ExtGStateEntries()
+	if len(entries) == 0 {
+		return nil
+	}
+
+	objects := make([]*IndirectObject, 0, len(entries))
+
+	for gsName, opacity := range entries {
+		objNum := w.allocateObjNum()
+
+		var buf bytes.Buffer
+		buf.WriteString("<< /Type /ExtGState")
+		buf.WriteString(fmt.Sprintf(" /ca %.2f /CA %.2f", opacity, opacity))
+		buf.WriteString(" >>")
+
+		objects = append(objects, NewIndirectObject(objNum, 0, buf.Bytes()))
+		resources.SetExtGStateObjNum(gsName, objNum)
+
+		logging.Logger().Debug("created ExtGState object",
+			"gsName", gsName,
+			"objNum", objNum,
+			"opacity", opacity,
+		)
+	}
+
+	return objects
 }
 
 // createAndAssignImageXObjects creates image XObject dictionary objects for all image operations

--- a/internal/writer/pages_test.go
+++ b/internal/writer/pages_test.go
@@ -328,6 +328,86 @@ func TestCreatePage_DifferentSizes(t *testing.T) {
 	}
 }
 
+func TestCreateExtGStateObjects(t *testing.T) {
+	w := &PdfWriter{
+		nextObjNum: 1,
+		objects:    make([]*IndirectObject, 0),
+		offsets:    make(map[int]int64),
+	}
+
+	resources := NewResourceDictionary()
+
+	// Register two ExtGState entries (placeholders with objNum=0).
+	name1, created1 := resources.GetOrCreateExtGState(0.5)
+	if !created1 {
+		t.Fatal("expected first GetOrCreateExtGState to return needsCreation=true")
+	}
+	name2, created2 := resources.GetOrCreateExtGState(0.3)
+	if !created2 {
+		t.Fatal("expected second GetOrCreateExtGState to return needsCreation=true")
+	}
+
+	// Before creating objects, both should have placeholder objNum=0.
+	if resources.GetExtGStateObjNum(name1) != 0 {
+		t.Errorf("expected objNum 0 for %s before creation, got %d", name1, resources.GetExtGStateObjNum(name1))
+	}
+	if resources.GetExtGStateObjNum(name2) != 0 {
+		t.Errorf("expected objNum 0 for %s before creation, got %d", name2, resources.GetExtGStateObjNum(name2))
+	}
+
+	// Create ExtGState objects.
+	objects := w.createExtGStateObjects(resources)
+
+	// Should have created 2 objects.
+	if len(objects) != 2 {
+		t.Fatalf("expected 2 ExtGState objects, got %d", len(objects))
+	}
+
+	// All object numbers must be > 0.
+	for _, obj := range objects {
+		if obj.Number <= 0 {
+			t.Errorf("ExtGState object has invalid number %d", obj.Number)
+		}
+		data := string(obj.Data)
+		if !strings.Contains(data, "/Type /ExtGState") {
+			t.Errorf("ExtGState object missing /Type /ExtGState: %s", data)
+		}
+		if !strings.Contains(data, "/ca ") || !strings.Contains(data, "/CA ") {
+			t.Errorf("ExtGState object missing /ca or /CA: %s", data)
+		}
+	}
+
+	// After creation, resource dictionary should have real object numbers.
+	if resources.GetExtGStateObjNum(name1) == 0 {
+		t.Errorf("expected objNum > 0 for %s after creation", name1)
+	}
+	if resources.GetExtGStateObjNum(name2) == 0 {
+		t.Errorf("expected objNum > 0 for %s after creation", name2)
+	}
+
+	// Resource dictionary bytes should NOT contain "0 0 R" for any GS entry.
+	resStr := resources.String()
+	if strings.Contains(resStr, " 0 0 R") {
+		t.Errorf("resource dictionary still contains '0 0 R' placeholder: %s", resStr)
+	}
+}
+
+func TestCreateExtGStateObjects_Empty(t *testing.T) {
+	w := &PdfWriter{
+		nextObjNum: 1,
+		objects:    make([]*IndirectObject, 0),
+		offsets:    make(map[int]int64),
+	}
+
+	resources := NewResourceDictionary()
+
+	// No ExtGState entries — should return nil.
+	objects := w.createExtGStateObjects(resources)
+	if objects != nil {
+		t.Errorf("expected nil for empty ExtGState, got %d objects", len(objects))
+	}
+}
+
 func TestCreatePageTree_EmptyDocument(t *testing.T) {
 	w := &PdfWriter{
 		nextObjNum: 1,

--- a/internal/writer/resource_dictionary.go
+++ b/internal/writer/resource_dictionary.go
@@ -257,6 +257,21 @@ func (rd *ResourceDictionary) GetExtGStateObjNum(name string) int {
 	return rd.extgstates[name]
 }
 
+// ExtGStateEntries returns a map of ExtGState resource name to opacity value.
+//
+// This is used by the writer to create actual ExtGState PDF objects for each
+// registered graphics state. The map is inverted from the internal cache
+// (opacity → name) to (name → opacity) for convenient iteration.
+//
+// Returns an empty map if no ExtGState entries are registered.
+func (rd *ResourceDictionary) ExtGStateEntries() map[string]float64 {
+	result := make(map[string]float64, len(rd.extgstateCache))
+	for opacity, name := range rd.extgstateCache {
+		result[name] = opacity
+	}
+	return result
+}
+
 // HasResources returns true if any resources are registered.
 //
 // Use this to check if the resource dictionary is empty before writing.


### PR DESCRIPTION
## Summary

Hotfix for shape and text opacity (#46, #47) — ExtGState objects were **never created as PDF indirect objects**.

- **Root cause**: `GetOrCreateExtGState()` registered entries with placeholder object number `0`, but no code materialized actual PDF objects. Resource dictionaries output `/GS1 0 0 R` — pointing to the xref free entry — silently ignored by PDF viewers.
- **Fix**: Add `createExtGStateObjects()` as STEP 3.6 in the writer pipeline, following the same pattern as fonts (STEP 3) and images (STEP 3.5). Both page creation paths fixed.
- **Tests**: Strengthened existing tests to detect `0 0 R` references; added end-to-end tests verifying real ExtGState dictionaries in output PDF.
- **Docs**: README roadmap section replaced with link to ROADMAP.md (version-agnostic). CHANGELOG updated for v0.5.1.

### Before (v0.5.0)
```
/ExtGState << /GS1 0 0 R >>   ← points to xref free entry, ignored
```

### After (v0.5.1)
```
/ExtGState << /GS1 7 0 R >>   ← real object
7 0 obj << /Type /ExtGState /ca 0.50 /CA 0.50 >> endobj
```

## Test plan

- [x] `go fmt ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — clean
- [x] Manual verification: generated PDF with shapes + text at different opacities, confirmed transparency visible in PDF viewer
