### PR TITLE
fix: prevent uint16 overflow in FontSubset.MeasureString

### DIFF
--- a/internal/fonts/font_subset.go
+++ b/internal/fonts/font_subset.go
@@ -146,9 +146,9 @@ func (s *FontSubset) GetCharWidth(ch rune) uint16 {
 
 // MeasureString returns the width of a string in points.
 func (s *FontSubset) MeasureString(text string, size float64) float64 {
-	var totalWidth uint16
+	var totalWidth int
 	for _, ch := range text {
-		totalWidth += s.GetCharWidth(ch)
+		totalWidth += int(s.GetCharWidth(ch))
 	}
 
 	// Convert from font units to points.

--- a/internal/fonts/font_subset_test.go
+++ b/internal/fonts/font_subset_test.go
@@ -233,3 +233,75 @@ func TestIdentifyUsedGlyphs(t *testing.T) {
 		t.Errorf("expected glyph 1 at index 1, got %d", glyphs[1])
 	}
 }
+
+// TestMeasureString_NoUint16Overflow is a regression test for the uint16
+// overflow bug where totalWidth silently wrapped at 65536 font-units.
+func TestMeasureString_NoUint16Overflow(t *testing.T) {
+	font := &TTFFont{
+		UnitsPerEm:  1000,
+		GlyphWidths: map[uint16]uint16{1: 1000},
+		CharToGlyph: map[rune]uint16{'W': 1},
+	}
+	subset := NewFontSubset(font)
+
+	// 65 chars × 1000 width = 65000 font-units (below uint16 max of 65535).
+	// 66 chars × 1000 width = 66000 font-units (above uint16 max — old code wraps to 464).
+	tests := []struct {
+		name  string
+		count int
+	}{
+		{"just_below_uint16_max", 65},
+		{"crosses_uint16_boundary", 66},
+		{"well_above_uint16_max", 100},
+		{"double_uint16_range", 131},
+	}
+
+	size := 1.0
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runes := make([]rune, tt.count)
+			for i := range runes {
+				runes[i] = 'W'
+			}
+			text := string(runes)
+
+			got := subset.MeasureString(text, size)
+			// Each char is 1000 font-units, UnitsPerEm=1000, size=1 → 1pt per char.
+			expected := float64(tt.count)
+			if got != expected {
+				t.Errorf("MeasureString(%d chars): got %.2f, want %.2f (delta=%.2f)",
+					tt.count, got, expected, got-expected)
+			}
+		})
+	}
+}
+
+// TestMeasureString_LinearScaling verifies that MeasureString scales linearly
+// with repetitions, catching any accumulator overflow at any multiplier.
+func TestMeasureString_LinearScaling(t *testing.T) {
+	font := &TTFFont{
+		UnitsPerEm:  2048,
+		GlyphWidths: map[uint16]uint16{1: 870},
+		CharToGlyph: map[rune]uint16{'H': 1},
+	}
+	subset := NewFontSubset(font)
+
+	base := "HHHHHHHHHH" // 10 chars × 870 = 8700 font-units per repeat
+	size := 12.0
+	baseWidth := subset.MeasureString(base, size)
+
+	for n := 1; n <= 20; n++ {
+		runes := make([]rune, 0, 10*n)
+		for i := 0; i < n; i++ {
+			runes = append(runes, []rune(base)...)
+		}
+		text := string(runes)
+
+		got := subset.MeasureString(text, size)
+		expected := baseWidth * float64(n)
+		delta := got - expected
+		if delta < -0.001 || delta > 0.001 {
+			t.Errorf("repeat=%d: got %.4f, want %.4f (delta=%.4f)", n, got, expected, delta)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fix `uint16` overflow in `FontSubset.MeasureString` that caused incorrect width calculations for long strings, breaking `FontBridge.LineBreak` text wrapping.

## Related Issue

Fixes the `uint16` overflow bug documented in `gxpdf-measurestring-overflow-bug.md`.

## Changes

- Changed `totalWidth` accumulator from `uint16` to `int` in `FontSubset.MeasureString` (`internal/fonts/font_subset.go`), matching the pattern already used in `FontMetrics.MeasureString`
- Added explicit `int()` cast when accumulating `GetCharWidth` results
- Added `TestMeasureString_NoUint16Overflow` regression test with boundary cases at/around the `uint16` maximum (65, 66, 100, 131 chars)
- Added `TestMeasureString_LinearScaling` test verifying linear width scaling for 1–20 repetitions

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Tests (adding or updating tests)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] Code follows the project's coding standards
- [x] `go fmt ./...` produces no changes
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [x] I have added tests for new functionality
- [ ] I have updated documentation as needed

## Screenshots / Examples

**Before fix** (uint16 overflow at 7 repeats of "Hello World " at 12pt):
```
 7 repeats: measured=  42.69  expected= 426.69  delta=-384.00  ← overflow
```

**After fix** (correct linear scaling):
```
 7 repeats: measured= 426.69  expected= 426.69  delta=   0.00  ✓
```

The delta of -384pt corresponds exactly to `65536 / 2048 × 12 = 384.0`, confirming the uint16 wrap.
