### PR TITLE
fix: correct CID TrueType text extraction for Identity-H fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.8.1] - 2026-05-21
+
+### Fixed
+- **CID TrueType text extraction** — `ExtractTextFromPage()` now correctly decodes CID TrueType fonts with Identity-H encoding and ToUnicode CMap (#74, @iv7dev)
+  - Implemented `beginbfrange` array format parsing (previously silently skipped, producing empty CMap)
+  - Fixed `use2ByteGlyphs` detection for Identity-H encoding in all `loadFontDecoder` fallback paths
+  - Added `begincodespacerange` parsing to determine byte width from the PDF spec-defined signal
+  - Added UTF-16BE surrogate pair decoding in CMap destinations (for supplementary Unicode planes)
+  - Prevented `looksLikeGarbage` heuristic from downgrading composite (Type0) fonts to 1-byte mode
+
+---
+
 ## [0.8.0] - 2026-05-07 "Extraction & Access"
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -130,6 +130,13 @@ Page sizes, custom dimensions, landscape orientation, and text rotation:
 
 ## Current Development
 
+### v0.8.1
+
+**Released**: May 2026
+
+- **CID TrueType text extraction fix** (#74, @iv7dev) — `ExtractTextFromPage()` now correctly decodes CID TrueType fonts with Identity-H encoding (wkhtmltopdf, TCPDF, CJK generators)
+- Fixed: `beginbfrange` array format, `begincodespacerange` parsing, UTF-16BE surrogate pairs, composite font 2-byte detection
+
 ### v0.8.0 "Extraction & Access"
 
 **Released**: May 2026

--- a/internal/extractor/cid_font_test.go
+++ b/internal/extractor/cid_font_test.go
@@ -1,0 +1,607 @@
+package extractor
+
+// Tests for bug #74: CID TrueType font text extraction returns raw glyph IDs.
+//
+// Covers all five root causes:
+//  1. parseBfRange array format
+//  2. No-ToUnicode path use2ByteGlyphs for Identity encoding
+//  3. begincodespacerange parsing
+//  4. UTF-16BE surrogate pair decoding
+//  5. isCompositeFont prevents garbage-detection downgrade to 1-byte
+
+import (
+	"bytes"
+	"compress/zlib"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/coregx/gxpdf/internal/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Bug 1: parseBfRange array format ────────────────────────────────────────
+
+func TestParseBfRange_ArrayFormat_ExplicitPerCodeMapping(t *testing.T) {
+	// Each source code maps to a specific destination — NOT a consecutive block.
+	// Format: <srcLow> <srcHigh> [<dst0> <dst1> <dst2>]
+	cmapData := `
+begincmap
+1 beginbfrange
+<0001> <0003> [<0041> <0042> <0043>]
+endbfrange
+endcmap
+`
+	table, err := ParseCMapStream([]byte(cmapData))
+	require.NoError(t, err)
+	assert.Equal(t, 3, table.Size())
+
+	tests := []struct {
+		glyphID uint16
+		want    rune
+		label   string
+	}{
+		{0x0001, 'A', "0x0001 → U+0041 A"},
+		{0x0002, 'B', "0x0002 → U+0042 B"},
+		{0x0003, 'C', "0x0003 → U+0043 C"},
+	}
+	for _, tt := range tests {
+		r, ok := table.GetUnicode(tt.glyphID)
+		assert.True(t, ok, tt.label)
+		assert.Equal(t, tt.want, r, tt.label)
+	}
+}
+
+func TestParseBfRange_ArrayFormat_CyrillicMappings(t *testing.T) {
+	// Simulate a real CID font bfrange with non-consecutive Cyrillic mappings.
+	cmapData := `
+begincmap
+1 beginbfrange
+<0001> <0004> [<0412> <044B> <043F> <0438>]
+endbfrange
+endcmap
+`
+	table, err := ParseCMapStream([]byte(cmapData))
+	require.NoError(t, err)
+	assert.Equal(t, 4, table.Size())
+
+	expected := map[uint16]rune{
+		0x0001: 'В', // U+0412
+		0x0002: 'ы', // U+044B
+		0x0003: 'п', // U+043F
+		0x0004: 'и', // U+0438
+	}
+	for gid, want := range expected {
+		r, ok := table.GetUnicode(gid)
+		assert.True(t, ok, "glyph 0x%04X should be mapped", gid)
+		assert.Equal(t, want, r, "glyph 0x%04X", gid)
+	}
+}
+
+func TestParseBfRange_ArrayFormat_TruncatedArray(t *testing.T) {
+	// Array has fewer entries than the range — only the first entries are mapped.
+	cmapData := `
+begincmap
+1 beginbfrange
+<0001> <0005> [<0041> <0042>]
+endbfrange
+endcmap
+`
+	table, err := ParseCMapStream([]byte(cmapData))
+	require.NoError(t, err)
+	// Only two entries available in the array
+	assert.Equal(t, 2, table.Size())
+
+	r, ok := table.GetUnicode(0x0001)
+	assert.True(t, ok)
+	assert.Equal(t, rune('A'), r)
+
+	r, ok = table.GetUnicode(0x0002)
+	assert.True(t, ok)
+	assert.Equal(t, rune('B'), r)
+
+	_, ok = table.GetUnicode(0x0003)
+	assert.False(t, ok, "0x0003 should not be mapped when array is shorter than range")
+}
+
+func TestParseBfRange_ScalarFormStillWorks(t *testing.T) {
+	// Verify the scalar form is unaffected by the array-form fix.
+	cmapData := `
+begincmap
+1 beginbfrange
+<0020> <007E> <0020>
+endbfrange
+endcmap
+`
+	table, err := ParseCMapStream([]byte(cmapData))
+	require.NoError(t, err)
+	assert.Equal(t, 0x7E-0x20+1, table.Size())
+
+	r, ok := table.GetUnicode(0x0041) // 'A'
+	assert.True(t, ok)
+	assert.Equal(t, rune('A'), r)
+}
+
+func TestParseBfRange_MixedScalarAndArray(t *testing.T) {
+	// Both forms in one bfrange section.
+	cmapData := `
+begincmap
+2 beginbfrange
+<0001> <0003> [<0041> <0042> <0043>]
+<0010> <0012> <0430>
+endbfrange
+endcmap
+`
+	table, err := ParseCMapStream([]byte(cmapData))
+	require.NoError(t, err)
+	assert.Equal(t, 6, table.Size())
+
+	// Array form
+	r, ok := table.GetUnicode(0x0001)
+	assert.True(t, ok)
+	assert.Equal(t, rune('A'), r)
+
+	// Scalar form
+	r, ok = table.GetUnicode(0x0010)
+	assert.True(t, ok)
+	assert.Equal(t, rune(0x0430), r) // 'а'
+
+	r, ok = table.GetUnicode(0x0012)
+	assert.True(t, ok)
+	assert.Equal(t, rune(0x0432), r) // 'в'
+}
+
+// ─── Bug 3: begincodespacerange parsing ──────────────────────────────────────
+
+func TestParseCodeSpaceRange_2ByteDetection(t *testing.T) {
+	// A CIDFont CMap declares <0000> <FFFF> — 4 hex chars = 2 bytes per code.
+	cmapData := `
+begincmap
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+1 beginbfchar
+<0001> <0041>
+endbfchar
+endcmap
+`
+	table, err := ParseCMapStream([]byte(cmapData))
+	require.NoError(t, err)
+	assert.Equal(t, 2, table.CodeBytes, "4-char hex in codespacerange → CodeBytes=2")
+}
+
+func TestParseCodeSpaceRange_1ByteDetection(t *testing.T) {
+	// A simple-font CMap declares <00> <FF> — 2 hex chars = 1 byte per code.
+	cmapData := `
+begincmap
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+1 beginbfchar
+<41> <0041>
+endbfchar
+endcmap
+`
+	table, err := ParseCMapStream([]byte(cmapData))
+	require.NoError(t, err)
+	assert.Equal(t, 1, table.CodeBytes, "2-char hex in codespacerange → CodeBytes=1")
+}
+
+func TestParseCodeSpaceRange_DefaultWhenAbsent(t *testing.T) {
+	// No codespacerange → default CodeBytes=1.
+	cmapData := `
+begincmap
+1 beginbfchar
+<01> <0041>
+endbfchar
+endcmap
+`
+	table, err := ParseCMapStream([]byte(cmapData))
+	require.NoError(t, err)
+	assert.Equal(t, 1, table.CodeBytes, "no codespacerange → CodeBytes defaults to 1")
+}
+
+func TestParseCodeSpaceRange_MultipleRanges_FirstDeterminesBytes(t *testing.T) {
+	cmapData := `
+begincmap
+2 begincodespacerange
+<0000> <00FF>
+<0100> <FFFF>
+endcodespacerange
+endcmap
+`
+	table, err := ParseCMapStream([]byte(cmapData))
+	require.NoError(t, err)
+	assert.Equal(t, 2, table.CodeBytes, "first entry has 4 hex chars → CodeBytes=2")
+}
+
+// ─── Bug 4: UTF-16BE surrogate pair decoding ─────────────────────────────────
+
+func TestDecodeUTF16BEHex_BMP_SingleCodePoint(t *testing.T) {
+	tests := []struct {
+		hex  string
+		want rune
+	}{
+		{"<0041>", 'A'},
+		{"<0412>", 'В'}, // Cyrillic capital VE
+		{"<FEFF>", '\uFEFF'},
+		{"<0020>", ' '},
+	}
+	for _, tt := range tests {
+		r, err := decodeUTF16BEHex(tt.hex)
+		require.NoError(t, err, "input: %s", tt.hex)
+		assert.Equal(t, tt.want, r, "input: %s", tt.hex)
+	}
+}
+
+func TestDecodeUTF16BEHex_SurrogatePair_Emoji(t *testing.T) {
+	// U+1F600 GRINNING FACE encoded as UTF-16BE surrogate pair: D83D DE00
+	r, err := decodeUTF16BEHex("<D83DDE00>")
+	require.NoError(t, err)
+	assert.Equal(t, rune(0x1F600), r, "surrogate pair D83D+DE00 → U+1F600")
+}
+
+func TestDecodeUTF16BEHex_SurrogatePair_LinearBSyllable(t *testing.T) {
+	// U+10000 LINEAR B SYLLABLE B008 A: D800 DC00
+	r, err := decodeUTF16BEHex("<D800DC00>")
+	require.NoError(t, err)
+	assert.Equal(t, rune(0x10000), r, "D800+DC00 → U+10000")
+}
+
+func TestDecodeUTF16BEHex_SingleByte(t *testing.T) {
+	r, err := decodeUTF16BEHex("<41>")
+	require.NoError(t, err)
+	assert.Equal(t, rune(0x41), r)
+}
+
+func TestDecodeUTF16BEHex_Empty_ReturnsError(t *testing.T) {
+	_, err := decodeUTF16BEHex("<>")
+	assert.Error(t, err)
+}
+
+func TestDecodeUTF16BEHex_InvalidHex_ReturnsError(t *testing.T) {
+	_, err := decodeUTF16BEHex("<ZZZZ>")
+	assert.Error(t, err)
+}
+
+func TestParseBfChar_SurrogatePairDestination(t *testing.T) {
+	// A ToUnicode CMap where the destination is a UTF-16BE surrogate pair (emoji).
+	cmapData := `
+begincmap
+1 beginbfchar
+<0001> <D83DDE00>
+endbfchar
+endcmap
+`
+	table, err := ParseCMapStream([]byte(cmapData))
+	require.NoError(t, err)
+
+	r, ok := table.GetUnicode(0x0001)
+	assert.True(t, ok)
+	assert.Equal(t, rune(0x1F600), r, "surrogate pair destination should decode to U+1F600")
+}
+
+func TestParseBfRange_SurrogatePairScalarBase(t *testing.T) {
+	// A bfrange starting at a surrogate-pair encoded code point (rare but valid).
+	// U+1F600 = D83D DE00, U+1F601 = D83D DE01
+	cmapData := `
+begincmap
+1 beginbfrange
+<0001> <0002> <D83DDE00>
+endbfrange
+endcmap
+`
+	table, err := ParseCMapStream([]byte(cmapData))
+	require.NoError(t, err)
+
+	r, ok := table.GetUnicode(0x0001)
+	assert.True(t, ok)
+	assert.Equal(t, rune(0x1F600), r)
+
+	// Range increments the rune — U+1F601
+	r, ok = table.GetUnicode(0x0002)
+	assert.True(t, ok)
+	assert.Equal(t, rune(0x1F601), r)
+}
+
+// ─── Bug 2: No-ToUnicode path uses use2ByteGlyphs for Identity encoding ──────
+
+func TestFontDecoder_IdentityEncoding_NoToUnicode_Uses2ByteGlyphs(t *testing.T) {
+	// Simulate loadFontDecoder path when Encoding=Identity-H and no ToUnicode.
+	// The decoder must use 2-byte glyphs.
+	decoder := NewFontDecoder(nil, "Identity-H", true)
+	assert.True(t, decoder.use2ByteGlyphs, "Identity-H without ToUnicode must use 2-byte glyphs")
+}
+
+func TestFontDecoder_IdentityV_Uses2ByteGlyphs(t *testing.T) {
+	decoder := NewFontDecoder(nil, "Identity-V", true)
+	assert.True(t, decoder.use2ByteGlyphs)
+}
+
+func TestFontDecoder_NonIdentityEncoding_Uses1ByteGlyphs(t *testing.T) {
+	decoder := NewFontDecoder(nil, "WinAnsiEncoding", false)
+	assert.False(t, decoder.use2ByteGlyphs, "WinAnsiEncoding is a 1-byte encoding")
+}
+
+// ─── Bug 5: isCompositeFont prevents garbage-detection downgrade ──────────────
+
+func TestFontDecoder_CompositeFont_DoesNotDowngradeTo1Byte(t *testing.T) {
+	// Create a CMap where all glyph IDs are > 0xFF (2-byte range).
+	cmap := NewCMapTable("Test")
+	cmap.AddMapping(0x0101, 'A') // glyph ID 0x0101 → 'A'
+	cmap.AddMapping(0x0102, 'B')
+	cmap.AddMapping(0x0103, 'C')
+
+	decoder := NewFontDecoder(cmap, "Identity-H", true)
+	decoder.isCompositeFont = true
+
+	// Bytes represent 2-byte glyph IDs: 0x0101, 0x0102, 0x0103
+	result := decoder.DecodeString([]byte{0x01, 0x01, 0x01, 0x02, 0x01, 0x03})
+	assert.Equal(t, "ABC", result)
+}
+
+func TestFontDecoder_SimpleFont_GarbageFallbackStillWorks(t *testing.T) {
+	// For non-composite fonts the garbage heuristic should still fall back.
+	// Use a CMap with no entries (everything unmapped → replacement chars).
+	cmap := NewCMapTable("Test")
+	decoder := NewFontDecoder(cmap, "Identity-H", true)
+	// isCompositeFont defaults to false — fallback is active.
+	assert.False(t, decoder.isCompositeFont)
+
+	// Input: 2-byte glyph IDs that map to U+FFFD (not in CMap).
+	// The fallback should try 1-byte decoding.
+	raw := []byte{0x41, 0x42, 0x43} // odd-length: can't be pure 2-byte
+	result := decoder.DecodeString(raw)
+	// With garbage fallback active, should produce something (not all U+FFFD)
+	assert.NotEmpty(t, result)
+}
+
+func TestFontDecoder_IsCompositeFont_FlagPreserved(t *testing.T) {
+	decoder := NewFontDecoder(nil, "Identity-H", true)
+	decoder.isCompositeFont = true
+	assert.True(t, decoder.isCompositeFont)
+}
+
+func TestFontDecoder_DefaultIsCompositeFont_False(t *testing.T) {
+	decoder := NewFontDecoder(nil, "", false)
+	assert.False(t, decoder.isCompositeFont, "new decoders default to simple font")
+}
+
+// ─── Integration test: Type0/CIDFontType2 with Identity-H + ToUnicode CMap ───
+
+// buildType0PDF constructs a minimal syntactically valid PDF containing:
+//   - Page 0 with a /Font entry /F1 of /Subtype /Type0
+//   - /Encoding /Identity-H
+//   - /DescendantFonts array with a CIDFontType2 descendant
+//   - A ToUnicode stream with bfchar mappings (including array-form bfrange)
+//   - A content stream that uses /F1 with 2-byte glyph codes
+//
+// The content stream writes glyph IDs 0x0001 (→ 'H'), 0x0002 (→ 'i'), 0x0003 (→ '!').
+//
+//nolint:funlen // PDF construction is inherently verbose
+func buildType0PDF(t *testing.T) []byte {
+	t.Helper()
+
+	// ToUnicode CMap: maps glyph IDs 0x0001-0x0003 to H, i, !
+	// Uses bfrange array format for 0x0001-0x0003.
+	toUnicodeCMap := `
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (Adobe)
+   /Ordering (UCS)
+   /Supplement 0
+>> def
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+
+1 beginbfrange
+<0001> <0003> [<0048> <0069> <0021>]
+endbfrange
+
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+`
+
+	// Content stream: BT /F1 12 Tf <0001> Tj <0002> Tj <0003> Tj ET
+	// Each <XXYY> is a 2-byte hex string encoded as a PDF string literal.
+	// In PDF content streams Tj takes a string; for 2-byte glyphs the string
+	// contains raw 2-byte sequences.
+	contentData := "BT /F1 12 Tf 100 700 Td (\x00\x01\x00\x02\x00\x03) Tj ET"
+
+	var pdf bytes.Buffer
+	pdf.WriteString("%PDF-1.7\n")
+
+	offsets := make([]int64, 12) // object slots 1-based
+
+	// Object 1: Catalog
+	offsets[1] = int64(pdf.Len())
+	pdf.WriteString("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+
+	// Object 2: Pages
+	offsets[2] = int64(pdf.Len())
+	pdf.WriteString("2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n")
+
+	// Compress content stream
+	var contentBuf bytes.Buffer
+	zlibW := zlib.NewWriter(&contentBuf)
+	_, err := zlibW.Write([]byte(contentData))
+	require.NoError(t, err)
+	require.NoError(t, zlibW.Close())
+	compressedContent := contentBuf.Bytes()
+
+	// Object 3: Page
+	offsets[3] = int64(pdf.Len())
+	pdf.WriteString("3 0 obj\n")
+	pdf.WriteString("<< /Type /Page /Parent 2 0 R\n")
+	pdf.WriteString("   /MediaBox [0 0 612 792]\n")
+	pdf.WriteString("   /Resources << /Font << /F1 4 0 R >> >>\n")
+	pdf.WriteString("   /Contents 8 0 R\n")
+	pdf.WriteString(">>\nendobj\n")
+
+	// Object 4: Type0 Font dict
+	offsets[4] = int64(pdf.Len())
+	pdf.WriteString("4 0 obj\n")
+	pdf.WriteString("<< /Type /Font\n")
+	pdf.WriteString("   /Subtype /Type0\n")
+	pdf.WriteString("   /BaseFont /ArialMT\n")
+	pdf.WriteString("   /Encoding /Identity-H\n")
+	pdf.WriteString("   /DescendantFonts [5 0 R]\n")
+	pdf.WriteString("   /ToUnicode 6 0 R\n")
+	pdf.WriteString(">>\nendobj\n")
+
+	// Object 5: CIDFontType2 (descendant)
+	offsets[5] = int64(pdf.Len())
+	pdf.WriteString("5 0 obj\n")
+	pdf.WriteString("<< /Type /Font\n")
+	pdf.WriteString("   /Subtype /CIDFontType2\n")
+	pdf.WriteString("   /BaseFont /ArialMT\n")
+	pdf.WriteString("   /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >>\n")
+	pdf.WriteString("   /DW 1000\n")
+	pdf.WriteString(">>\nendobj\n")
+
+	// Object 6: ToUnicode stream (uncompressed for simplicity)
+	offsets[6] = int64(pdf.Len())
+	pdf.WriteString("6 0 obj\n")
+	pdf.WriteString(fmt.Sprintf("<< /Length %d >>\n", len(toUnicodeCMap)))
+	pdf.WriteString("stream\n")
+	pdf.WriteString(toUnicodeCMap)
+	pdf.WriteString("\nendstream\nendobj\n")
+
+	// Object 8: Content stream (compressed)
+	offsets[8] = int64(pdf.Len())
+	pdf.WriteString("8 0 obj\n")
+	pdf.WriteString(fmt.Sprintf("<< /Filter /FlateDecode /Length %d >>\n", len(compressedContent)))
+	pdf.WriteString("stream\n")
+	pdf.Write(compressedContent)
+	pdf.WriteString("\nendstream\nendobj\n")
+
+	// Cross-reference table (6 objects: 1-6, 8)
+	xrefOffset := int64(pdf.Len())
+	pdf.WriteString("xref\n")
+	pdf.WriteString("0 9\n")
+	pdf.WriteString("0000000000 65535 f \n")
+	for i := 1; i <= 8; i++ {
+		if offsets[i] == 0 && i != 7 {
+			// Object 7 intentionally unused
+			pdf.WriteString("0000000000 65535 f \n")
+			continue
+		}
+		if i == 7 {
+			pdf.WriteString("0000000000 65535 f \n")
+			continue
+		}
+		pdf.WriteString(fmt.Sprintf("%010d 00000 n \n", offsets[i]))
+	}
+
+	pdf.WriteString("trailer\n")
+	pdf.WriteString("<< /Size 9 /Root 1 0 R >>\n")
+	pdf.WriteString("startxref\n")
+	pdf.WriteString(fmt.Sprintf("%d\n", xrefOffset))
+	pdf.WriteString("%%EOF\n")
+
+	return pdf.Bytes()
+}
+
+func TestCIDFont_Integration_Type0WithToUnicode(t *testing.T) {
+	pdfBytes := buildType0PDF(t)
+
+	tmpDir := t.TempDir()
+	pdfPath := filepath.Join(tmpDir, "cid_font.pdf")
+	require.NoError(t, os.WriteFile(pdfPath, pdfBytes, 0600))
+
+	rd, err := parser.OpenPDF(pdfPath)
+	require.NoError(t, err)
+	defer func() { _ = rd.Close() }()
+
+	te := NewTextExtractor(rd)
+	elements, err := te.ExtractFromPage(0)
+	require.NoError(t, err)
+	require.NotEmpty(t, elements, "should extract at least one text element")
+
+	// Concatenate all extracted text
+	var sb strings.Builder
+	for _, el := range elements {
+		sb.WriteString(el.Text)
+	}
+	extracted := sb.String()
+
+	// The CMap maps 0x0001→H, 0x0002→i, 0x0003→!
+	// Content stream sends glyph sequence 0x0001 0x0002 0x0003
+	assert.Equal(t, "Hi!", extracted,
+		"CID TrueType font with ToUnicode + bfrange array must produce correct Unicode text; got %q", extracted)
+}
+
+// ─── Additional edge-case tests ───────────────────────────────────────────────
+
+func TestParseBfRange_EmptyArray_NoMappings(t *testing.T) {
+	cmapData := `
+begincmap
+1 beginbfrange
+<0001> <0005> []
+endbfrange
+endcmap
+`
+	table, err := ParseCMapStream([]byte(cmapData))
+	require.NoError(t, err)
+	// Empty array → no mappings should be added
+	assert.Equal(t, 0, table.Size())
+}
+
+func TestCMapTable_CodeBytes_InitializesTo1(t *testing.T) {
+	table := NewCMapTable("test")
+	assert.Equal(t, 1, table.CodeBytes, "fresh CMapTable must default to CodeBytes=1")
+}
+
+func TestExtractHexTokensFromArray_Basic(t *testing.T) {
+	inner := "<0041> <0042> <0043>"
+	tokens := extractHexTokensFromArray(inner)
+	assert.Equal(t, []string{"<0041>", "<0042>", "<0043>"}, tokens)
+}
+
+func TestExtractHexTokensFromArray_WithWhitespace(t *testing.T) {
+	inner := "  <0041>  \n  <0042>  "
+	tokens := extractHexTokensFromArray(inner)
+	assert.Equal(t, []string{"<0041>", "<0042>"}, tokens)
+}
+
+func TestExtractHexTokensFromArray_Empty(t *testing.T) {
+	tokens := extractHexTokensFromArray("")
+	assert.Empty(t, tokens)
+}
+
+func TestHexStringToBytes_Valid(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []byte
+	}{
+		{"0041", []byte{0x00, 0x41}},
+		{"D83DDE00", []byte{0xD8, 0x3D, 0xDE, 0x00}},
+		{"FF", []byte{0xFF}},
+	}
+	for _, tt := range tests {
+		got, err := hexStringToBytes(tt.input)
+		require.NoError(t, err, "input: %q", tt.input)
+		assert.Equal(t, tt.want, got)
+	}
+}
+
+func TestHexStringToBytes_OddLength_Error(t *testing.T) {
+	_, err := hexStringToBytes("041")
+	assert.Error(t, err)
+}
+
+func TestHexStringToBytes_InvalidHex_Error(t *testing.T) {
+	_, err := hexStringToBytes("ZZZZ")
+	assert.Error(t, err)
+}

--- a/internal/extractor/cmap_parser.go
+++ b/internal/extractor/cmap_parser.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode/utf16"
 )
 
 // CMapTable represents a Character Map that maps glyph IDs to Unicode code points.
@@ -25,13 +26,19 @@ type CMapTable struct {
 
 	// name is the CMap name (e.g., "Adobe-Identity-UCS")
 	name string
+
+	// CodeBytes is the number of bytes per character code as declared in
+	// begincodespacerange. 1 for single-byte fonts, 2 for CIDFonts with
+	// Identity-H/V encoding. Defaults to 1 when not parsed.
+	CodeBytes int
 }
 
 // NewCMapTable creates a new empty CMapTable.
 func NewCMapTable(name string) *CMapTable {
 	return &CMapTable{
-		mappings: make(map[uint16]rune),
-		name:     name,
+		mappings:  make(map[uint16]rune),
+		name:      name,
+		CodeBytes: 1, // default; overridden by begincodespacerange
 	}
 }
 
@@ -142,6 +149,15 @@ func (p *CMapParser) Parse() (*CMapTable, error) {
 				table.name = strings.TrimPrefix(name, "/")
 			}
 
+		case "begincodespacerange":
+			// Parse code space range to determine bytes-per-character-code.
+			// Format:
+			//   N begincodespacerange
+			//   <low> <high>
+			//   ...
+			//   endcodespacerange
+			p.parseCodeSpaceRange(table)
+
 		case "beginbfchar":
 			// Parse single character mappings
 			if err := p.parseBfChar(table); err != nil {
@@ -172,6 +188,8 @@ func (p *CMapParser) Parse() (*CMapTable, error) {
 //	<srcCode2> <dstCode2>
 //	...
 //	endbfchar
+//
+// The destination code may be a UTF-16BE surrogate pair (8 hex chars = 4 bytes).
 func (p *CMapParser) parseBfChar(table *CMapTable) error {
 	for {
 		token := p.nextToken()
@@ -191,20 +209,21 @@ func (p *CMapParser) parseBfChar(table *CMapTable) error {
 			return fmt.Errorf("invalid bfchar mapping: missing destination code")
 		}
 
-		// Parse hex strings
+		// Parse source glyph ID
 		glyphID, err := parseHexString(srcCode)
 		if err != nil {
 			// Skip invalid mappings
 			continue
 		}
 
-		unicode, err := parseHexString(dstCode)
+		// Parse destination as UTF-16BE (handles surrogate pairs)
+		r, err := decodeUTF16BEHex(dstCode)
 		if err != nil {
 			// Skip invalid mappings
 			continue
 		}
 
-		table.AddMapping(uint16(glyphID), rune(unicode))
+		table.AddMapping(uint16(glyphID), r)
 	}
 
 	return nil
@@ -212,15 +231,17 @@ func (p *CMapParser) parseBfChar(table *CMapTable) error {
 
 // parseBfRange parses beginbfrange...endbfrange section.
 //
-// Format:
+// Supports two forms:
 //
-//	2 beginbfrange
-//	<srcCodeLow1> <srcCodeHigh1> <dstCodeLow1>
-//	<srcCodeLow2> <srcCodeHigh2> <dstCodeLow2>
-//	...
-//	endbfrange
+//  1. Scalar form (consecutive Unicode block):
+//     <srcLow> <srcHigh> <dstLow>
+//     Maps srcLow+i → dstLow+i for each i in [0, srcHigh-srcLow].
 //
-// Maps a range of source codes to consecutive destination codes.
+//  2. Array form (explicit per-code mapping):
+//     <srcLow> <srcHigh> [<dst0> <dst1> ... <dstN>]
+//     Maps srcLow+i → dst_i exactly.
+//
+// Reference: PDF 1.7 specification, Section 9.7.5 (ToUnicode CMaps).
 func (p *CMapParser) parseBfRange(table *CMapTable) error {
 	for {
 		token := p.nextToken()
@@ -235,17 +256,17 @@ func (p *CMapParser) parseBfRange(table *CMapTable) error {
 
 		srcLow := token
 		srcHigh := p.nextToken()
-		dstLow := p.nextToken()
+		dstToken := p.nextToken()
 
-		if srcHigh == "" || dstLow == "" {
+		if srcHigh == "" || dstToken == "" {
 			return fmt.Errorf("invalid bfrange mapping: incomplete range")
 		}
 
-		if !strings.HasPrefix(srcHigh, "<") || !strings.HasPrefix(dstLow, "<") {
+		if !strings.HasPrefix(srcHigh, "<") {
 			continue
 		}
 
-		// Parse hex strings
+		// Parse source range boundaries
 		startGlyphID, err := parseHexString(srcLow)
 		if err != nil {
 			continue
@@ -256,23 +277,206 @@ func (p *CMapParser) parseBfRange(table *CMapTable) error {
 			continue
 		}
 
-		startUnicode, err := parseHexString(dstLow)
+		// Array form: [<dst0> <dst1> ... <dstN>]
+		// nextToken() returns the full "[...]" as a single token.
+		if strings.HasPrefix(dstToken, "[") {
+			p.parseBfRangeArray(table, uint16(startGlyphID), uint16(endGlyphID), dstToken)
+			continue
+		}
+
+		// Scalar form: <dstLow> — consecutive Unicode block
+		if !strings.HasPrefix(dstToken, "<") {
+			continue
+		}
+
+		startUnicode, err := decodeUTF16BEHex(dstToken)
 		if err != nil {
 			continue
 		}
 
-		// Check for array format: <srcLow> <srcHigh> [<dst1> <dst2> ...]
-		// For now, we only support scalar destination (most common case)
-		if strings.HasPrefix(dstLow, "[") {
-			// Array format - skip for now (Phase 1)
-			// This would map each source code to a specific destination code
-			continue
-		}
-
-		table.AddRangeMapping(uint16(startGlyphID), uint16(endGlyphID), rune(startUnicode))
+		table.AddRangeMapping(uint16(startGlyphID), uint16(endGlyphID), startUnicode)
 	}
 
 	return nil
+}
+
+// parseBfRangeArray handles the array form of bfrange:
+//
+//	<srcLow> <srcHigh> [<dst0> <dst1> ... <dstN>]
+//
+// Each element in the array is a hex string that maps to the corresponding
+// source code: srcLow+i → dst_i. The array token has already been consumed
+// by nextToken() as the full "[...]" string.
+func (p *CMapParser) parseBfRangeArray(table *CMapTable, srcLow, srcHigh uint16, arrayToken string) {
+	// Strip the enclosing brackets
+	inner := strings.TrimPrefix(arrayToken, "[")
+	inner = strings.TrimSuffix(inner, "]")
+	inner = strings.TrimSpace(inner)
+
+	if inner == "" {
+		return
+	}
+
+	// Parse individual hex tokens from the bracket content.
+	// Each token is of the form <XXXX>.
+	hexTokens := extractHexTokensFromArray(inner)
+
+	srcCode := srcLow
+	for _, hexToken := range hexTokens {
+		if srcCode > srcHigh {
+			break
+		}
+
+		r, err := decodeUTF16BEHex(hexToken)
+		if err != nil {
+			srcCode++
+			continue
+		}
+
+		table.AddMapping(srcCode, r)
+		srcCode++
+	}
+}
+
+// extractHexTokensFromArray parses the interior of a [...] bracket, extracting
+// individual <hex> tokens. Non-hex content is silently skipped.
+func extractHexTokensFromArray(s string) []string {
+	var tokens []string
+	for i := 0; i < len(s); {
+		// Skip whitespace
+		if s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r' {
+			i++
+			continue
+		}
+		if s[i] == '<' {
+			// Find the closing >
+			end := strings.IndexByte(s[i:], '>')
+			if end < 0 {
+				break
+			}
+			tokens = append(tokens, s[i:i+end+1])
+			i += end + 1
+			continue
+		}
+		i++
+	}
+	return tokens
+}
+
+// parseCodeSpaceRange parses the begincodespacerange...endcodespacerange section.
+//
+// Format:
+//
+//	N begincodespacerange
+//	<low> <high>
+//	...
+//	endcodespacerange
+//
+// The hex string length of <low> or <high> reveals the bytes-per-code:
+// 2 hex chars = 1 byte, 4 hex chars = 2 bytes.
+// We use the first entry to set table.CodeBytes.
+func (p *CMapParser) parseCodeSpaceRange(table *CMapTable) {
+	first := true
+	for {
+		token := p.nextToken()
+		if token == "" || token == "endcodespacerange" {
+			break
+		}
+
+		if !strings.HasPrefix(token, "<") {
+			continue
+		}
+
+		// Consume the matching high end token
+		high := p.nextToken()
+		if high == "" {
+			break
+		}
+
+		if first {
+			// Hex string body length: strip < and >
+			body := strings.TrimPrefix(token, "<")
+			body = strings.TrimSuffix(body, ">")
+			// 4 hex chars = 2 bytes (CIDFont), 2 hex chars = 1 byte (simple font)
+			if len(body) >= 4 {
+				table.CodeBytes = 2
+			} else {
+				table.CodeBytes = 1
+			}
+			first = false
+		}
+	}
+}
+
+// decodeUTF16BEHex decodes a hex string (e.g., "<0041>" or "<D83DDE00>") to a rune.
+//
+// The hex string may encode:
+//   - A single BMP code point (2 bytes / 4 hex chars): decode as big-endian uint16
+//   - A UTF-16BE surrogate pair (4 bytes / 8 hex chars): decode via utf16.DecodeRune
+//
+// Returns an error for empty or malformed input.
+func decodeUTF16BEHex(hexStr string) (rune, error) {
+	body := strings.TrimPrefix(hexStr, "<")
+	body = strings.TrimSuffix(body, ">")
+
+	if body == "" {
+		return 0, fmt.Errorf("empty hex string")
+	}
+
+	// Pad odd-length hex strings to even (shouldn't normally happen)
+	if len(body)%2 != 0 {
+		body = "0" + body
+	}
+
+	// Parse raw bytes
+	rawBytes, err := hexStringToBytes(body)
+	if err != nil {
+		return 0, err
+	}
+
+	switch len(rawBytes) {
+	case 1:
+		return rune(rawBytes[0]), nil
+	case 2:
+		// Single BMP code point
+		u16 := uint16(rawBytes[0])<<8 | uint16(rawBytes[1])
+		return rune(u16), nil
+	case 4:
+		// Possible UTF-16BE surrogate pair
+		high := uint16(rawBytes[0])<<8 | uint16(rawBytes[1])
+		low := uint16(rawBytes[2])<<8 | uint16(rawBytes[3])
+		if high >= 0xD800 && high <= 0xDBFF {
+			// Confirmed surrogate pair
+			return utf16.DecodeRune(rune(high), rune(low)), nil
+		}
+		// Not a surrogate — treat as 32-bit code point (rare)
+		cp := rune(rawBytes[0])<<24 | rune(rawBytes[1])<<16 | rune(rawBytes[2])<<8 | rune(rawBytes[3])
+		return cp, nil
+	default:
+		// For > 4 bytes, fall back to integer parsing
+		val, err2 := strconv.ParseInt(body, 16, 64)
+		if err2 != nil {
+			return 0, fmt.Errorf("invalid hex string %q: %w", hexStr, err2)
+		}
+		return rune(val), nil
+	}
+}
+
+// hexStringToBytes converts a hex string (no angle brackets) to a byte slice.
+func hexStringToBytes(hex string) ([]byte, error) {
+	if len(hex)%2 != 0 {
+		return nil, fmt.Errorf("odd-length hex string: %q", hex)
+	}
+	result := make([]byte, len(hex)/2)
+	for i := range result {
+		nibbles := hex[i*2 : i*2+2]
+		val, err := strconv.ParseUint(nibbles, 16, 8)
+		if err != nil {
+			return nil, fmt.Errorf("invalid hex byte %q in %q: %w", nibbles, hex, err)
+		}
+		result[i] = byte(val)
+	}
+	return result, nil
 }
 
 // nextToken reads the next token from the stream.

--- a/internal/extractor/font_decoder.go
+++ b/internal/extractor/font_decoder.go
@@ -31,6 +31,11 @@ type FontDecoder struct {
 	// customEncoding is a custom glyph ID → Unicode mapping from /Encoding/Differences
 	// This is used when a font defines custom glyph mappings via the Differences array.
 	customEncoding map[uint16]rune
+
+	// isCompositeFont is true when the source font is a Type0 (composite) font.
+	// For composite fonts the 2-byte character codes are authoritative — the
+	// garbage heuristic fallback to 1-byte must never be applied.
+	isCompositeFont bool
 }
 
 // NewFontDecoder creates a new FontDecoder with the given CMap and encoding.
@@ -95,8 +100,12 @@ func (d *FontDecoder) DecodeString(glyphBytes []byte) string {
 	decodedStr := d.decodeWithGlyphSize(glyphBytes, d.use2ByteGlyphs)
 
 	// FALLBACK: If result contains too many non-printable chars (garbage),
-	// try alternate glyph size (1-byte if was 2-byte, vice versa)
-	if d.use2ByteGlyphs && d.looksLikeGarbage(decodedStr) {
+	// try alternate glyph size (1-byte if was 2-byte, vice versa).
+	//
+	// Exception: composite (Type0) fonts MUST NOT fall back to 1-byte decoding.
+	// Their 2-byte character codes are authoritative; applying a 1-byte fallback
+	// would silently corrupt every CID glyph ID above 0x00FF.
+	if d.use2ByteGlyphs && !d.isCompositeFont && d.looksLikeGarbage(decodedStr) {
 		// Try 1-byte glyphs instead
 		decodedStr1Byte := d.decodeWithGlyphSize(glyphBytes, false)
 		if !d.looksLikeGarbage(decodedStr1Byte) {

--- a/internal/extractor/text_extractor.go
+++ b/internal/extractor/text_extractor.go
@@ -601,16 +601,34 @@ func (te *TextExtractor) loadFontDecoder(fontName string) {
 		}
 	}
 
+	// Detect whether this is a composite (Type0) font. Composite fonts use
+	// 2-byte character codes and must never be downgraded to 1-byte decoding.
+	isType0 := false
+	if subtypeObj := fontDict.Get("Subtype"); subtypeObj != nil {
+		if subtypeName, ok := subtypeObj.(*parser.Name); ok {
+			isType0 = subtypeName.Value() == "Type0"
+		}
+	}
+
+	// Identity-H/V and composite fonts always use 2-byte glyph codes.
+	use2ByteGlyphs := strings.Contains(encodingName, "Identity") || isType0
+
 	// Try to get ToUnicode CMap
 	toUnicodeObj := fontDict.Get("ToUnicode")
 	if toUnicodeObj == nil {
 		// No ToUnicode CMap - check if we have Differences array
 		if differences != nil && len(differences) > 0 {
-			// Create decoder with custom encoding (Differences array)
+			// Create decoder with custom encoding (Differences array).
+			// use2ByteGlyphs is false for simple fonts with Differences.
 			te.fontDecoders[fontName] = NewFontDecoderWithCustomEncoding(differences, encodingName, false)
 		} else {
-			// Fallback: create decoder with encoding name only
-			te.fontDecoders[fontName] = NewFontDecoder(nil, encodingName, false)
+			// Fallback: create decoder with encoding name only.
+			// For Identity-H/V and Type0 fonts, honor 2-byte mode.
+			decoder := NewFontDecoder(nil, encodingName, use2ByteGlyphs)
+			if isType0 {
+				decoder.isCompositeFont = true
+			}
+			te.fontDecoders[fontName] = decoder
 		}
 		return
 	}
@@ -628,7 +646,11 @@ func (te *TextExtractor) loadFontDecoder(fontName string) {
 
 	if toUnicodeStream == nil {
 		// ToUnicode is not a stream - create decoder with encoding only
-		te.fontDecoders[fontName] = NewFontDecoder(nil, encodingName, false)
+		decoder := NewFontDecoder(nil, encodingName, use2ByteGlyphs)
+		if isType0 {
+			decoder.isCompositeFont = true
+		}
+		te.fontDecoders[fontName] = decoder
 		return
 	}
 
@@ -636,7 +658,11 @@ func (te *TextExtractor) loadFontDecoder(fontName string) {
 	cmapData, err := te.decodeStream(toUnicodeStream)
 	if err != nil {
 		// Failed to decode stream - create decoder with encoding only
-		te.fontDecoders[fontName] = NewFontDecoder(nil, encodingName, false)
+		decoder := NewFontDecoder(nil, encodingName, use2ByteGlyphs)
+		if isType0 {
+			decoder.isCompositeFont = true
+		}
+		te.fontDecoders[fontName] = decoder
 		return
 	}
 
@@ -644,14 +670,25 @@ func (te *TextExtractor) loadFontDecoder(fontName string) {
 	cmap, err := ParseCMapStream(cmapData)
 	if err != nil {
 		// Failed to parse CMap - create decoder with encoding only
-		te.fontDecoders[fontName] = NewFontDecoder(nil, encodingName, false)
+		decoder := NewFontDecoder(nil, encodingName, use2ByteGlyphs)
+		if isType0 {
+			decoder.isCompositeFont = true
+		}
+		te.fontDecoders[fontName] = decoder
 		return
 	}
 
+	// When begincodespacerange declared 2-byte codes, honor that even if
+	// no Identity encoding name was present (e.g. some CJK fonts).
+	if cmap.CodeBytes == 2 {
+		use2ByteGlyphs = true
+	}
+
 	// Create decoder with CMap
-	// Important: Identity-H/Identity-V encodings always use 2-byte glyphs
-	use2ByteGlyphs := strings.Contains(encodingName, "Identity")
 	decoder := NewFontDecoder(cmap, encodingName, use2ByteGlyphs)
+	if isType0 {
+		decoder.isCompositeFont = true
+	}
 
 	// Add Differences array if present (for fonts with custom encoding)
 	if differences != nil && len(differences) > 0 {


### PR DESCRIPTION
## Summary

Fix CID TrueType font text extraction that returned raw glyph IDs (`\x01 \x02 \x03`) or empty strings instead of Unicode text for PDFs with Identity-H encoding and ToUnicode CMap.

Five bugs fixed in the CMap/font decoder pipeline:

1. **`beginbfrange` array format** — previously silently skipped, now fully parsed
2. **Identity-H 2-byte detection** — all `loadFontDecoder` fallback paths now honor 2-byte mode
3. **`begincodespacerange` parsing** — byte width determined from PDF spec signal
4. **UTF-16BE surrogate pairs** — CMap destinations for U+10000+ now correctly decoded
5. **Composite font guard** — `looksLikeGarbage` heuristic no longer downgrades Type0 fonts

Fixes #74

## Test plan

- [x] `go fmt ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — 23 packages, all passing
- [x] `golangci-lint run` — no new issues
- [x] 33 new tests: bfrange array parsing, codespacerange detection, surrogate pair decoding, composite font guard, end-to-end integration with synthetic Type0/CIDFontType2 PDF
- [x] All existing CMap and font decoder tests still pass
- [x] Zero breaking changes
- [x] CHANGELOG, ROADMAP updated
