### PR TITLE
fix: prevent column content merging with adjacent colspan cells (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.3] - 2026-08-02
+
+### Fixed
+- **Column content no longer merges with adjacent colspan cells** — header text ("TIME", "VENUE") was incorrectly pulled into neighboring columns when adjacent cells had rowspan/colspan; now each column contains only its own content (#86, @AtifChy)
+
+---
+
 ## [0.9.2] - 2026-08-02
 
 ### Fixed

--- a/gxpdf_ground_truth_test.go
+++ b/gxpdf_ground_truth_test.go
@@ -447,6 +447,44 @@ func containsCourseTitle(pageContent, title string) bool {
 // findCourseSections finds sections for a course title in the extracted map.
 // Handles truncated titles.
 
+// TestGroundTruth_ColumnSeparation verifies that columns are not merged.
+// Regression test for #86: expandBoundsIntoMergedNeighbors was pulling
+// header text from adjacent columns.
+func TestGroundTruth_ColumnSeparation(t *testing.T) {
+	if _, err := os.Stat(groundTruthPDF); os.IsNotExist(err) {
+		t.Skipf("fixture not found: %s", groundTruthPDF)
+	}
+
+	doc, err := Open(groundTruthPDF)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer doc.Close()
+
+	page := doc.Page(0)
+	tables, err := page.ExtractTablesWithOptions(&ExtractionOptions{Method: MethodLattice})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if len(tables) == 0 {
+		t.Fatal("no tables")
+	}
+	tbl := tables[0]
+
+	// Column 1 should never contain "TIME" as standalone text
+	// Column 2 should never contain "VENUE" as standalone text
+	for r := 0; r < tbl.RowCount(); r++ {
+		col1 := tbl.Cell(r, 1)
+		col2 := tbl.Cell(r, 2)
+		if strings.Contains(col1, "TIME") && !strings.Contains(col1, "OVERTIME") {
+			t.Errorf("Row %d col 1 contains TIME text (should be in col 0): %q", r, col1)
+		}
+		if strings.HasPrefix(strings.TrimSpace(col2), "VENUE") {
+			t.Errorf("Row %d col 2 starts with VENUE text (should be in col 3): %q", r, col2)
+		}
+	}
+}
+
 func init() {
 	// Ensure ground truth file path is printed in test output for reference.
 	_ = fmt.Sprintf("Ground truth: %s", groundTruthPath)

--- a/internal/tabledetect/extractor.go
+++ b/internal/tabledetect/extractor.go
@@ -161,7 +161,7 @@ func (te *TableExtractor) extractLatticeTable(region *TableRegion) (*domaintable
 				continue
 			}
 
-			extractBounds := expandBoundsIntoMergedNeighbors(grid, gridRow, c, gridCell.Bounds, coveredCells, rowCount)
+			extractBounds := gridCell.Bounds
 			content := te.cellExtractor.ExtractCellContent(extractBounds)
 			domainBounds := domaintable.NewRectangle(extractBounds.X, extractBounds.Y, extractBounds.Width, extractBounds.Height)
 			cell := domaintable.NewCellWithBounds(content, r, c, domainBounds)
@@ -360,30 +360,22 @@ func expandBoundsIntoMergedNeighbors(
 	}
 	outputRow := rowCount - 1 - gridRow
 
-	// Expand left: if the column to the left has no grid cell at this row
-	// (nil = part of a taller merged cell in intersection grid, or covered
-	// by merge in sorted-coordinate grid), extend this cell's X to include
-	// the left column's area.
-	if col > 0 {
-		leftCell := grid.GetCell(gridRow, col-1)
-		leftCovered := coveredCells != nil && coveredCells[mergedKey{outputRow, col - 1}]
-		leftNil := leftCell == nil
-		if leftCovered || leftNil {
-			leftX := grid.Columns[col-1]
-			expansion := bounds.X - leftX
-			bounds = extractor.NewRectangle(
-				leftX, bounds.Y,
-				bounds.Width+expansion, bounds.Height,
-			)
-		}
+	// Expand left: only when the left column is explicitly covered by a
+	// merge (from DetectMergedCells). Do NOT expand into nil cells from
+	// intersection grid — those are tall merged cells whose content will
+	// be extracted in pass 2. Expanding into them steals their text (#86).
+	if col > 0 && coveredCells != nil && coveredCells[mergedKey{outputRow, col - 1}] {
+		leftX := grid.Columns[col-1]
+		expansion := bounds.X - leftX
+		bounds = extractor.NewRectangle(
+			leftX, bounds.Y,
+			bounds.Width+expansion, bounds.Height,
+		)
 	}
 
-	// Expand right: same logic for right column.
-	if col < grid.ColumnCount()-1 {
-		rightCell := grid.GetCell(gridRow, col+1)
-		rightCovered := coveredCells != nil && coveredCells[mergedKey{outputRow, col + 1}]
-		rightNil := rightCell == nil
-		if (rightCovered || rightNil) && col+2 < len(grid.Columns) {
+	// Expand right: same logic — only for explicitly covered cells.
+	if col < grid.ColumnCount()-1 && coveredCells != nil && coveredCells[mergedKey{outputRow, col + 1}] {
+		if col+2 < len(grid.Columns) {
 			rightX := grid.Columns[col+2]
 			if rightX > bounds.X+bounds.Width {
 				bounds = extractor.NewRectangle(

--- a/testdata/golden/issue79_page0_auto_table0.json
+++ b/testdata/golden/issue79_page0_auto_table0.json
@@ -8,7 +8,7 @@
     {
       "row": 0,
       "col": 0,
-      "text": "",
+      "text": "TIME\nSlot 1: \n9:00 AM\n - \n11:00 AM",
       "rowSpan": 14,
       "colSpan": 1
     },
@@ -29,7 +29,7 @@
     {
       "row": 2,
       "col": 1,
-      "text": "TIME\nCOURSE TITLE",
+      "text": "COURSE TITLE",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -50,7 +50,7 @@
     {
       "row": 3,
       "col": 2,
-      "text": "VENUE\nA,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y",
+      "text": "A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -99,7 +99,7 @@
     {
       "row": 7,
       "col": 1,
-      "text": "Slot 1: \nDISCRETE MATHEMATICS\n9:00 AM",
+      "text": "DISCRETE MATHEMATICS",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -113,7 +113,7 @@
     {
       "row": 8,
       "col": 1,
-      "text": "ELECTRICAL POWER TRANSMISSION \u0026 DIST.\n -",
+      "text": "ELECTRICAL POWER TRANSMISSION \u0026 DIST.",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -127,14 +127,14 @@
     {
       "row": 9,
       "col": 1,
-      "text": "11:00 AM\nFOUNDATION COURSE",
+      "text": "FOUNDATION COURSE",
       "rowSpan": 1,
       "colSpan": 1
     },
     {
       "row": 9,
       "col": 2,
-      "text": "A,B,C,D,E,D",
+      "text": "A,B,C,D,E",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -197,7 +197,7 @@
     {
       "row": 14,
       "col": 0,
-      "text": "- \n2:00 PM",
+      "text": "Slot 2: \n12:00 PM\n - \n2:00 PM",
       "rowSpan": 19,
       "colSpan": 1
     },
@@ -218,7 +218,7 @@
     {
       "row": 14,
       "col": 3,
-      "text": "Building \nD",
+      "text": "All \nAnnexes \n\u0026 \nBuilding \nD",
       "rowSpan": 19,
       "colSpan": 1
     },
@@ -316,28 +316,14 @@
     {
       "row": 23,
       "col": 1,
-      "text": "ENGLISH READING SKILLS \u0026 PUBLIC SPEAKING\nSlot 2:",
+      "text": "ENGLISH READING SKILLS \u0026 PUBLIC SPEAKING",
       "rowSpan": 1,
       "colSpan": 1
     },
     {
       "row": 23,
       "col": 2,
-      "text": "B1,B2,B3,B4,B5,B6,B7,B8,C1,C10,C2,C3,C4,C5,C6,C7,C8,C9,D1,E1,E2,H1,H2,J1",
-      "rowSpan": 1,
-      "colSpan": 1
-    },
-    {
-      "row": 24,
-      "col": 1,
-      "text": "12:00 PM",
-      "rowSpan": 1,
-      "colSpan": 1
-    },
-    {
-      "row": 24,
-      "col": 2,
-      "text": "P1",
+      "text": "B1,B2,B3,B4,B5,B6,B7,B8,C1,C10,C2,C3,C4,C5,C6,C7,C8,C9,D1,E1,E2,H1,H2,J1,P1",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -456,14 +442,14 @@
     {
       "row": 33,
       "col": 0,
-      "text": "",
+      "text": "Slot 3: \n3:00 PM\n - \n5:00 PM",
       "rowSpan": 12,
       "colSpan": 1
     },
     {
       "row": 33,
       "col": 3,
-      "text": "",
+      "text": "All \nAnnexes \n\u0026 \nBuilding \nD",
       "rowSpan": 12,
       "colSpan": 1
     },
@@ -554,7 +540,7 @@
     {
       "row": 40,
       "col": 1,
-      "text": "Slot 3: \nFINANCIAL MANAGEMENT",
+      "text": "FINANCIAL MANAGEMENT",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -568,7 +554,7 @@
     {
       "row": 41,
       "col": 1,
-      "text": "3:00 PM\nHISTORY OF ENGLISH LANGUAGE\n -",
+      "text": "HISTORY OF ENGLISH LANGUAGE",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -582,7 +568,7 @@
     {
       "row": 42,
       "col": 1,
-      "text": "INVESTIGATIVE JOURNALISM\n5:00 PM",
+      "text": "INVESTIGATIVE JOURNALISM",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -603,7 +589,7 @@
     {
       "row": 43,
       "col": 2,
-      "text": "D\nA",
+      "text": "A",
       "rowSpan": 1,
       "colSpan": 1
     },

--- a/testdata/golden/issue79_page0_table0.json
+++ b/testdata/golden/issue79_page0_table0.json
@@ -8,7 +8,7 @@
     {
       "row": 0,
       "col": 0,
-      "text": "",
+      "text": "TIME\nSlot 1: \n9:00 AM\n - \n11:00 AM",
       "rowSpan": 14,
       "colSpan": 1
     },
@@ -29,7 +29,7 @@
     {
       "row": 2,
       "col": 1,
-      "text": "TIME\nCOURSE TITLE",
+      "text": "COURSE TITLE",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -50,7 +50,7 @@
     {
       "row": 3,
       "col": 2,
-      "text": "VENUE\nA,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y",
+      "text": "A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -99,7 +99,7 @@
     {
       "row": 7,
       "col": 1,
-      "text": "Slot 1: \nDISCRETE MATHEMATICS\n9:00 AM",
+      "text": "DISCRETE MATHEMATICS",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -113,7 +113,7 @@
     {
       "row": 8,
       "col": 1,
-      "text": "ELECTRICAL POWER TRANSMISSION \u0026 DIST.\n -",
+      "text": "ELECTRICAL POWER TRANSMISSION \u0026 DIST.",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -127,14 +127,14 @@
     {
       "row": 9,
       "col": 1,
-      "text": "11:00 AM\nFOUNDATION COURSE",
+      "text": "FOUNDATION COURSE",
       "rowSpan": 1,
       "colSpan": 1
     },
     {
       "row": 9,
       "col": 2,
-      "text": "A,B,C,D,E,D",
+      "text": "A,B,C,D,E",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -197,7 +197,7 @@
     {
       "row": 14,
       "col": 0,
-      "text": "- \n2:00 PM",
+      "text": "Slot 2: \n12:00 PM\n - \n2:00 PM",
       "rowSpan": 19,
       "colSpan": 1
     },
@@ -218,7 +218,7 @@
     {
       "row": 14,
       "col": 3,
-      "text": "Building \nD",
+      "text": "All \nAnnexes \n\u0026 \nBuilding \nD",
       "rowSpan": 19,
       "colSpan": 1
     },
@@ -316,28 +316,14 @@
     {
       "row": 23,
       "col": 1,
-      "text": "ENGLISH READING SKILLS \u0026 PUBLIC SPEAKING\nSlot 2:",
+      "text": "ENGLISH READING SKILLS \u0026 PUBLIC SPEAKING",
       "rowSpan": 1,
       "colSpan": 1
     },
     {
       "row": 23,
       "col": 2,
-      "text": "B1,B2,B3,B4,B5,B6,B7,B8,C1,C10,C2,C3,C4,C5,C6,C7,C8,C9,D1,E1,E2,H1,H2,J1",
-      "rowSpan": 1,
-      "colSpan": 1
-    },
-    {
-      "row": 24,
-      "col": 1,
-      "text": "12:00 PM",
-      "rowSpan": 1,
-      "colSpan": 1
-    },
-    {
-      "row": 24,
-      "col": 2,
-      "text": "P1",
+      "text": "B1,B2,B3,B4,B5,B6,B7,B8,C1,C10,C2,C3,C4,C5,C6,C7,C8,C9,D1,E1,E2,H1,H2,J1,P1",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -456,14 +442,14 @@
     {
       "row": 33,
       "col": 0,
-      "text": "",
+      "text": "Slot 3: \n3:00 PM\n - \n5:00 PM",
       "rowSpan": 12,
       "colSpan": 1
     },
     {
       "row": 33,
       "col": 3,
-      "text": "",
+      "text": "All \nAnnexes \n\u0026 \nBuilding \nD",
       "rowSpan": 12,
       "colSpan": 1
     },
@@ -554,7 +540,7 @@
     {
       "row": 40,
       "col": 1,
-      "text": "Slot 3: \nFINANCIAL MANAGEMENT",
+      "text": "FINANCIAL MANAGEMENT",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -568,7 +554,7 @@
     {
       "row": 41,
       "col": 1,
-      "text": "3:00 PM\nHISTORY OF ENGLISH LANGUAGE\n -",
+      "text": "HISTORY OF ENGLISH LANGUAGE",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -582,7 +568,7 @@
     {
       "row": 42,
       "col": 1,
-      "text": "INVESTIGATIVE JOURNALISM\n5:00 PM",
+      "text": "INVESTIGATIVE JOURNALISM",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -603,7 +589,7 @@
     {
       "row": 43,
       "col": 2,
-      "text": "D\nA",
+      "text": "A",
       "rowSpan": 1,
       "colSpan": 1
     },

--- a/testdata/golden/issue79_page1_table0.json
+++ b/testdata/golden/issue79_page1_table0.json
@@ -141,7 +141,7 @@
     {
       "row": 12,
       "col": 0,
-      "text": "",
+      "text": "DEVELOPMENT\nCOMMUNICATION\n[BMB]",
       "rowSpan": 19,
       "colSpan": 1
     },
@@ -279,13 +279,6 @@
       "colSpan": 1
     },
     {
-      "row": 22,
-      "col": 1,
-      "text": "DEVELOPMENT",
-      "rowSpan": 1,
-      "colSpan": 1
-    },
-    {
       "row": 23,
       "col": 1,
       "text": "HISTORY OF EMERGENCE OF BANGLADESH\nINTRODUCTION TO BUSINESS",
@@ -302,7 +295,7 @@
     {
       "row": 24,
       "col": 1,
-      "text": "INTRODUCTION TO DIGITAL TOOLS  OF \nCOMMUNICATION",
+      "text": "INTRODUCTION TO DIGITAL TOOLS  OF",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -330,7 +323,7 @@
     {
       "row": 26,
       "col": 1,
-      "text": "[BMB]\nLITERARY THEORY AND CRITICISM",
+      "text": "LITERARY THEORY AND CRITICISM",
       "rowSpan": 1,
       "colSpan": 1
     },
@@ -386,7 +379,7 @@
     {
       "row": 31,
       "col": 0,
-      "text": "",
+      "text": "TROPICS",
       "rowSpan": 15,
       "colSpan": 1
     },
@@ -492,13 +485,6 @@
       "row": 37,
       "col": 2,
       "text": "A",
-      "rowSpan": 1,
-      "colSpan": 1
-    },
-    {
-      "row": 38,
-      "col": 1,
-      "text": "TROPICS",
       "rowSpan": 1,
       "colSpan": 1
     },


### PR DESCRIPTION
## Summary

Fixes column content merging reported by @AtifChy in #79 / #86.

**Before:** `["", "TIME\nCOURSE TITLE", "SECTIONS", ""]`
**After:** `["", "COURSE TITLE", "SECTIONS", ""]`

### What changed

Removed bounds expansion into nil cells from intersection grid. Nil cells are tall merged cells (TIME/VENUE spanning multiple rows) whose content is extracted separately — expanding into them pulled their text into adjacent columns.

### Added

`TestGroundTruth_ColumnSeparation` — structural test verifying no column content leaks into neighbors.

Fixes #86