### PR TITLE
fix: prevent panic on TTF table offset/length overflow

### DIFF
--- a/internal/fonts/ttf_overflow_test.go
+++ b/internal/fonts/ttf_overflow_test.go
@@ -1,0 +1,42 @@
+package fonts
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// A table entry whose Offset+Length overflows uint32 must be rejected, not
+// panic on an out-of-bounds slice. The bounds check adds two uint32 values,
+// so a wrap-around (e.g. Offset=0xFFFFFFFF, Length=2) passes the check while
+// the subsequent slice data[Offset:Offset+Length] is out of range.
+func TestLoadTTFFromBytes_TableOffsetLengthOverflow(t *testing.T) {
+	var b []byte
+	put32 := func(v uint32) {
+		tmp := make([]byte, 4)
+		binary.BigEndian.PutUint32(tmp, v)
+		b = append(b, tmp...)
+	}
+	put16 := func(v uint16) {
+		tmp := make([]byte, 2)
+		binary.BigEndian.PutUint16(tmp, v)
+		b = append(b, tmp...)
+	}
+
+	put32(0x00010000) // sfnt version (TrueType)
+	put16(1)          // numTables
+	put16(0)          // searchRange
+	put16(0)          // entrySelector
+	put16(0)          // rangeShift
+
+	// One table directory entry.
+	b = append(b, []byte("cmap")...) // tag
+	put32(0)                         // checksum
+	put32(0xFFFFFFFF)                // offset
+	put32(2)                         // length -> offset+length wraps to 1
+
+	// Some trailing data so len(data) > 1.
+	b = append(b, make([]byte, 32)...)
+
+	// Must not panic.
+	_, _ = LoadTTFFromBytes(b)
+}

--- a/internal/fonts/ttf_parser.go
+++ b/internal/fonts/ttf_parser.go
@@ -278,7 +278,8 @@ func (f *TTFFont) loadTables(data []byte) error {
 // loadTable loads data for a single table.
 func (f *TTFFont) loadTable(data []byte, table *TTFTable) error {
 	//nolint:gosec // len(data) from file size, typically < 2GB.
-	if table.Offset+table.Length > uint32(len(data)) {
+	dataLen := uint32(len(data))
+	if table.Offset > dataLen || table.Length > dataLen-table.Offset {
 		return fmt.Errorf("table offset/length out of bounds")
 	}
 	table.Data = data[table.Offset : table.Offset+table.Length]


### PR DESCRIPTION
## Problem

`loadTable` validates a TrueType table's bounds like this:

```go
func (f *TTFFont) loadTable(data []byte, table *TTFTable) error {
	if table.Offset+table.Length > uint32(len(data)) {
		return fmt.Errorf("table offset/length out of bounds")
	}
	table.Data = data[table.Offset : table.Offset+table.Length]
	return nil
}
```

`table.Offset` and `table.Length` are `uint32` values read directly from the font's table directory (`parseTableEntry`). Their sum is computed in `uint32`, so it can **overflow and wrap** to a small value that passes the check. The subsequent `data[table.Offset : table.Offset+table.Length]` then slices with an out-of-range low bound and panics.

Embedded fonts are attacker-controlled: a font extracted from an untrusted PDF reaches this code via the exported `LoadTTFFromBytes`.

### Reproduction

A minimal TrueType font with one table entry where `Offset = 0xFFFFFFFF`, `Length = 2` (sum wraps to `1`):

```
panic: runtime error: slice bounds out of range [4294967295:1]
    internal/fonts/ttf_parser.go: table.Data = data[table.Offset : table.Offset+table.Length]
```

## Fix

Check the bounds without the wrapping addition:

```go
dataLen := uint32(len(data))
if table.Offset > dataLen || table.Length > dataLen-table.Offset {
	return fmt.Errorf("table offset/length out of bounds")
}
```

`dataLen - table.Offset` is only evaluated after confirming `table.Offset <= dataLen`, so it cannot underflow.

## Tests

`TestLoadTTFFromBytes_TableOffsetLengthOverflow` crafts the overflowing font and asserts no panic. It panics on the current code and passes with the fix.

Validation:
```
go test -short -race ./...       # all packages pass
GOARCH=386 go test -short ./internal/fonts/   # 32-bit path ok
go vet ./...                     # clean
gofmt -l .                       # my files clean
golangci-lint run ./internal/fonts/...   # no new issues in changed files
```
