### PR TITLE
fix: preserve terminal table columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Form XObject text geometry** — compose page `cm`, Form `/Matrix`, and nested glyph transforms for unit-sized positioned text; isolate Form graphics state, use embedded font widths, and bound hostile composite `/W` ranges (#89)
+
 ---
 
 ## [0.9.4] - 2026-08-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Form XObject text geometry** — compose page `cm`, Form `/Matrix`, and nested glyph transforms for unit-sized positioned text; isolate Form graphics state, use embedded font widths, and bound hostile composite `/W` ranges (#89)
-- **Terminal table columns** — preserve the rightmost content edge and compact whitespace-only intervals so Stream table reconstruction does not drop the final populated column (#94)
+- **Terminal table columns** — preserve the rightmost supported content edge, ignore unrelated page text, and compact whitespace-only intervals so Stream table reconstruction neither drops the final populated column nor creates a phantom successor (#94)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Form XObject text geometry** — compose page `cm`, Form `/Matrix`, and nested glyph transforms for unit-sized positioned text; isolate Form graphics state, use embedded font widths, and bound hostile composite `/W` ranges (#89)
+- **Terminal table columns** — preserve the rightmost content edge and compact whitespace-only intervals so Stream table reconstruction does not drop the final populated column (#94)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Form XObject text geometry** — compose page `cm`, Form `/Matrix`, and nested glyph transforms for unit-sized positioned text; isolate Form graphics state, use embedded font widths, and bound hostile composite `/W` ranges (#89)
-- **Terminal table columns** — preserve the rightmost supported content edge, ignore unrelated page text, and compact whitespace-only intervals so Stream table reconstruction neither drops the final populated column nor creates a phantom successor (#94)
+- **Terminal table columns** — preserve rightmost values on regular, sparse, and section-separated rows; reject nearby page-number metadata; and compact whitespace-only intervals so Stream reconstruction neither drops the final populated column nor creates a phantom successor (#94)
 
 ---
 

--- a/form_positioned_table_test.go
+++ b/form_positioned_table_test.go
@@ -1,0 +1,48 @@
+package gxpdf
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestFormPositionedGeometryReachesTableDetection verifies the public handoff:
+// corrected Form glyph geometry must reach the table detector instead of leaving
+// a native-text table undiscoverable. Exact multi-column reconstruction is a
+// separate concern and is intentionally not frozen by this regression test.
+func TestFormPositionedGeometryReachesTableDetection(t *testing.T) {
+	methods := []ExtractionMethod{MethodAuto, MethodStream, MethodLattice, MethodHybrid}
+	for _, method := range methods {
+		t.Run(method.String(), func(t *testing.T) {
+			document, err := Open(filepath.Join("testdata", "pdfs", "form_positioned_table.pdf"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer document.Close()
+
+			tables, err := document.ExtractTablesWithOptions(DefaultExtractionOptions().WithMethod(method))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(tables) != 1 {
+				t.Fatalf("tables = %d, want 1", len(tables))
+			}
+			rows := tables[0].Rows()
+			for _, label := range []string{"Line Item", "Revenue", "Cost of Sales"} {
+				if !tableContainsText(rows, label) {
+					t.Errorf("table does not contain %q: %#v", label, rows)
+				}
+			}
+		})
+	}
+}
+
+func tableContainsText(rows [][]string, want string) bool {
+	for _, row := range rows {
+		for _, cell := range row {
+			if cell == want {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/form_positioned_table_test.go
+++ b/form_positioned_table_test.go
@@ -37,3 +37,26 @@ func TestFormPositionedGeometryReachesTableDetection(t *testing.T) {
 		})
 	}
 }
+
+func TestFormPositionedTableIgnoresFarRightPageText(t *testing.T) {
+	document, err := Open(filepath.Join("testdata", "pdfs", "form_positioned_table_outlier.pdf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer document.Close()
+
+	tables, err := document.ExtractTablesWithOptions(DefaultExtractionOptions().WithMethod(MethodStream))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tables) != 1 {
+		t.Fatalf("tables = %d, want 1", len(tables))
+	}
+	if got := tables[0].ColumnCount(); got != 3 {
+		t.Fatalf("columns = %d, want 3", got)
+	}
+	rows := tables[0].Rows()
+	if len(rows) < 4 || rows[2][2] != "1450" || rows[3][2] != "(570)" {
+		t.Fatalf("terminal table values were not retained: %#v", rows)
+	}
+}

--- a/form_positioned_table_test.go
+++ b/form_positioned_table_test.go
@@ -56,7 +56,13 @@ func TestFormPositionedTableIgnoresFarRightPageText(t *testing.T) {
 		t.Fatalf("columns = %d, want 3", got)
 	}
 	rows := tables[0].Rows()
-	if len(rows) < 4 || rows[2][2] != "1450" || rows[3][2] != "(570)" {
-		t.Fatalf("terminal table values were not retained: %#v", rows)
+	want := [][]string{
+		{"Income Statement", "", ""},
+		{"Line Item", "2023", "2024"},
+		{"Revenue", "1200", "1450"},
+		{"Cost of Sales", "(400)", "(570)"},
+	}
+	if !reflect.DeepEqual(rows, want) {
+		t.Fatalf("table rows = %#v, want %#v", rows, want)
 	}
 }

--- a/form_positioned_table_test.go
+++ b/form_positioned_table_test.go
@@ -66,3 +66,59 @@ func TestFormPositionedTableIgnoresFarRightPageText(t *testing.T) {
 		t.Fatalf("table rows = %#v, want %#v", rows, want)
 	}
 }
+
+func TestFormPositionedTableBoundaryCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		fixture string
+		want    [][]string
+	}{
+		{
+			name:    "nearby footer row",
+			fixture: "form_positioned_table_near_footer.pdf",
+			want: [][]string{
+				{"Income Statement", "", ""},
+				{"Line Item", "2023", "2024"},
+				{"Revenue", "1200", "1450"},
+				{"Cost of Sales", "(400)", "(570)"},
+			},
+		},
+		{
+			name:    "sparse value after section gap",
+			fixture: "form_positioned_table_sparse_section.pdf",
+			want: [][]string{
+				{"Income Statement", "", ""},
+				{"Line Item", "2023", ""},
+				{"Revenue", "1200", ""},
+				{"Cost of Sales", "(400)", ""},
+				{"Other", "", "900"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertFormPositionedTableRows(t, test.fixture, test.want)
+		})
+	}
+}
+
+func assertFormPositionedTableRows(t *testing.T, fixture string, want [][]string) {
+	t.Helper()
+	document, err := Open(filepath.Join("testdata", "pdfs", fixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer document.Close()
+
+	tables, err := document.ExtractTablesWithOptions(DefaultExtractionOptions().WithMethod(MethodStream))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tables) != 1 {
+		t.Fatalf("tables = %d, want 1", len(tables))
+	}
+	if got := tables[0].Rows(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("table rows = %#v, want %#v", got, want)
+	}
+}

--- a/form_positioned_table_test.go
+++ b/form_positioned_table_test.go
@@ -28,7 +28,7 @@ func TestFormPositionedGeometryReachesTableDetection(t *testing.T) {
 			}
 			rows := tables[0].Rows()
 			for _, label := range []string{"Line Item", "Revenue", "Cost of Sales"} {
-				if !tableContainsText(rows, label) {
+				if !formTableContainsText(rows, label) {
 					t.Errorf("table does not contain %q: %#v", label, rows)
 				}
 			}
@@ -36,7 +36,7 @@ func TestFormPositionedGeometryReachesTableDetection(t *testing.T) {
 	}
 }
 
-func tableContainsText(rows [][]string, want string) bool {
+func formTableContainsText(rows [][]string, want string) bool {
 	for _, row := range rows {
 		for _, cell := range row {
 			if cell == want {

--- a/form_positioned_table_test.go
+++ b/form_positioned_table_test.go
@@ -2,14 +2,19 @@ package gxpdf
 
 import (
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
-// TestFormPositionedGeometryReachesTableDetection verifies the public handoff:
-// corrected Form glyph geometry must reach the table detector instead of leaving
-// a native-text table undiscoverable. Exact multi-column reconstruction is a
-// separate concern and is intentionally not frozen by this regression test.
+// TestFormPositionedGeometryReachesTableDetection verifies the complete public
+// handoff from corrected Form glyph geometry through table reconstruction.
 func TestFormPositionedGeometryReachesTableDetection(t *testing.T) {
+	want := [][]string{
+		{"Income Statement", "", ""},
+		{"Line Item", "2023", "2024"},
+		{"Revenue", "1200", "1450"},
+		{"Cost of Sales", "(400)", "(570)"},
+	}
 	methods := []ExtractionMethod{MethodAuto, MethodStream, MethodLattice, MethodHybrid}
 	for _, method := range methods {
 		t.Run(method.String(), func(t *testing.T) {
@@ -26,23 +31,9 @@ func TestFormPositionedGeometryReachesTableDetection(t *testing.T) {
 			if len(tables) != 1 {
 				t.Fatalf("tables = %d, want 1", len(tables))
 			}
-			rows := tables[0].Rows()
-			for _, label := range []string{"Line Item", "Revenue", "Cost of Sales"} {
-				if !formTableContainsText(rows, label) {
-					t.Errorf("table does not contain %q: %#v", label, rows)
-				}
+			if got := tables[0].Rows(); !reflect.DeepEqual(got, want) {
+				t.Errorf("table rows = %#v, want %#v", got, want)
 			}
 		})
 	}
-}
-
-func formTableContainsText(rows [][]string, want string) bool {
-	for _, row := range rows {
-		for _, cell := range row {
-			if cell == want {
-				return true
-			}
-		}
-	}
-	return false
 }

--- a/gxpdf_golden_test.go
+++ b/gxpdf_golden_test.go
@@ -319,3 +319,19 @@ func TestGolden_Issue79_AutoMode(t *testing.T) {
 		opts,
 	)
 }
+
+// TestGolden_FormPositionedTable_Stream locks the complete three-column
+// reconstruction, including the narrow terminal numeric column.
+func TestGolden_FormPositionedTable_Stream(t *testing.T) {
+	opts := DefaultExtractionOptions().
+		WithMethod(MethodStream).
+		WithPages(0)
+
+	runGoldenTest(t,
+		"form_positioned_table_stream_table0",
+		"testdata/pdfs/form_positioned_table.pdf",
+		0,
+		0,
+		opts,
+	)
+}

--- a/internal/extractor/font_extractor.go
+++ b/internal/extractor/font_extractor.go
@@ -172,7 +172,7 @@ func (fe *FontExtractor) extractFontData(fontDict *parser.Dictionary) (*Embedded
 	var err error
 
 	switch subtype {
-	case "Type0":
+	case type0FontSubtype:
 		// Composite font: descriptor lives inside DescendantFonts.
 		descriptorDict, err = fe.descriptorFromType0(fontDict)
 		if err != nil || descriptorDict == nil {

--- a/internal/extractor/font_extractor.go
+++ b/internal/extractor/font_extractor.go
@@ -268,7 +268,7 @@ func (fe *FontExtractor) fontFileData(descriptor *parser.Dictionary) ([]byte, er
 
 // resolveDict resolves an indirect reference and casts to *parser.Dictionary.
 func (fe *FontExtractor) resolveDict(obj parser.PdfObject) (*parser.Dictionary, error) {
-	obj = fe.resolve(obj)
+	obj = resolveObject(fe.reader, obj)
 	if obj == nil {
 		return nil, nil
 	}
@@ -281,7 +281,7 @@ func (fe *FontExtractor) resolveDict(obj parser.PdfObject) (*parser.Dictionary, 
 
 // resolveArray resolves an indirect reference and casts to *parser.Array.
 func (fe *FontExtractor) resolveArray(obj parser.PdfObject) (*parser.Array, error) {
-	obj = fe.resolve(obj)
+	obj = resolveObject(fe.reader, obj)
 	if obj == nil {
 		return nil, nil
 	}
@@ -294,7 +294,7 @@ func (fe *FontExtractor) resolveArray(obj parser.PdfObject) (*parser.Array, erro
 
 // resolveStream resolves an indirect reference and casts to *parser.Stream.
 func (fe *FontExtractor) resolveStream(obj parser.PdfObject) (*parser.Stream, error) {
-	obj = fe.resolve(obj)
+	obj = resolveObject(fe.reader, obj)
 	if obj == nil {
 		return nil, nil
 	}
@@ -303,20 +303,6 @@ func (fe *FontExtractor) resolveStream(obj parser.PdfObject) (*parser.Stream, er
 		return nil, nil
 	}
 	return stream, nil
-}
-
-// resolve follows a single indirect reference using the reader's object table.
-// Non-reference objects are returned as-is. Returns nil on resolution error.
-func (fe *FontExtractor) resolve(obj parser.PdfObject) parser.PdfObject {
-	ref, ok := obj.(*parser.IndirectReference)
-	if !ok {
-		return obj
-	}
-	resolved, err := fe.reader.GetObject(ref.Number)
-	if err != nil {
-		return nil
-	}
-	return resolved
 }
 
 // nameValue extracts the string value from a *parser.Name object.
@@ -353,7 +339,7 @@ func (fe *FontExtractor) encodingValue(obj parser.PdfObject) string {
 	if obj == nil {
 		return ""
 	}
-	obj = fe.resolve(obj)
+	obj = resolveObject(fe.reader, obj)
 	if obj == nil {
 		return ""
 	}

--- a/internal/extractor/font_metrics.go
+++ b/internal/extractor/font_metrics.go
@@ -125,7 +125,7 @@ func (te *TextExtractor) loadCompositeFontMetrics(fontDict *parser.Dictionary) *
 		if !ok {
 			break
 		}
-		first := int(firstObj.Value())
+		first := firstObj.Value()
 		i++
 		if i >= widths.Len() {
 			break
@@ -133,8 +133,9 @@ func (te *TextExtractor) loadCompositeFontMetrics(fontDict *parser.Dictionary) *
 
 		if explicit, ok := te.resolveObject(widths.Get(i)).(*parser.Array); ok {
 			for offset := 0; offset < explicit.Len(); offset++ {
-				if width := getNumber(explicit.Get(offset)); width != nil && first+offset >= 0 && first+offset <= 65535 {
-					metrics.widths[uint16(first+offset)] = *width
+				glyphID := first + int64(offset)
+				if width := getNumber(explicit.Get(offset)); width != nil && glyphID >= 0 && glyphID <= 65535 {
+					metrics.widths[uint16(glyphID)] = *width
 				}
 			}
 			i++
@@ -149,11 +150,18 @@ func (te *TextExtractor) loadCompositeFontMetrics(fontDict *parser.Dictionary) *
 		if width == nil {
 			break
 		}
-		last := int(lastObj.Value())
-		for glyphID := first; glyphID <= last && glyphID <= 65535; glyphID++ {
-			if glyphID >= 0 {
-				metrics.widths[uint16(glyphID)] = *width
-			}
+		last := lastObj.Value()
+		// CID values are unsigned 16-bit identifiers. Clamp both ends before
+		// iterating so a hostile negative cFirst cannot turn a malformed /W
+		// range into billions of no-op loop iterations.
+		if first < 0 {
+			first = 0
+		}
+		if last > 65535 {
+			last = 65535
+		}
+		for glyphID := first; glyphID <= last; glyphID++ {
+			metrics.widths[uint16(glyphID)] = *width
 		}
 		i += 2
 	}

--- a/internal/extractor/font_metrics.go
+++ b/internal/extractor/font_metrics.go
@@ -1,0 +1,172 @@
+package extractor
+
+import "github.com/coregx/gxpdf/internal/parser"
+
+const type0FontSubtype = "Type0"
+
+// fontMetrics contains glyph advances in the PDF's standard 1000-unit text
+// space. Simple fonts define /FirstChar and /Widths; composite Type0 fonts
+// define /DW and /W on their descendant CIDFont.
+type fontMetrics struct {
+	widths       map[uint16]float64
+	defaultWidth float64
+	precise      bool
+}
+
+func (fm *fontMetrics) width(glyphID uint16) float64 {
+	if fm == nil {
+		return 600
+	}
+	if width, ok := fm.widths[glyphID]; ok {
+		return width
+	}
+	return fm.defaultWidth
+}
+
+// measureGlyphBytes returns the text advance, visible width, and whether the
+// width came from authoritative PDF font metrics.
+func (te *TextExtractor) measureGlyphBytes(glyphBytes []byte) (float64, float64, bool) {
+	decoder := te.fontDecoders[te.textState.FontName]
+	metrics := te.fontMetrics[te.textState.FontName]
+	horizontalScale := te.textState.HorizScale / 100.0
+
+	advance := 0.0
+	visibleWidth := 0.0
+	for position := 0; position < len(glyphBytes); {
+		glyphID, bytesRead := uint16(glyphBytes[position]), 1
+		if decoder != nil {
+			glyphID, bytesRead = decoder.readGlyphID(glyphBytes[position:])
+		}
+		if bytesRead <= 0 {
+			break
+		}
+
+		glyphWidth := metrics.width(glyphID) / 1000.0 * te.textState.FontSize * horizontalScale
+		visibleWidth = advance + glyphWidth
+
+		spacing := te.textState.CharSpace
+		if glyphID == 32 && (decoder == nil || !decoder.isCompositeFont) {
+			spacing += te.textState.WordSpace
+		}
+		advance = visibleWidth + spacing*horizontalScale
+		position += bytesRead
+	}
+
+	return advance, visibleWidth, metrics != nil && metrics.precise
+}
+
+func (te *TextExtractor) loadFontMetrics(fontDict *parser.Dictionary) *fontMetrics {
+	if fontDict == nil {
+		return nil
+	}
+
+	if subtype, ok := fontDict.Get("Subtype").(*parser.Name); ok && subtype.Value() == type0FontSubtype {
+		return te.loadCompositeFontMetrics(fontDict)
+	}
+	return te.loadSimpleFontMetrics(fontDict)
+}
+
+func (te *TextExtractor) loadSimpleFontMetrics(fontDict *parser.Dictionary) *fontMetrics {
+	firstCharObj, ok := fontDict.Get("FirstChar").(*parser.Integer)
+	if !ok {
+		return nil
+	}
+	widthsObj := te.resolveObject(fontDict.Get("Widths"))
+	widthsArray, ok := widthsObj.(*parser.Array)
+	if !ok || widthsArray.Len() == 0 {
+		return nil
+	}
+
+	metrics := &fontMetrics{
+		widths:       make(map[uint16]float64, widthsArray.Len()),
+		defaultWidth: 600,
+		precise:      true,
+	}
+	firstChar := int(firstCharObj.Value())
+	for i := 0; i < widthsArray.Len(); i++ {
+		if width := getNumber(widthsArray.Get(i)); width != nil && firstChar+i >= 0 && firstChar+i <= 65535 {
+			metrics.widths[uint16(firstChar+i)] = *width
+		}
+	}
+
+	if descriptor, ok := te.resolveObject(fontDict.Get("FontDescriptor")).(*parser.Dictionary); ok {
+		if missingWidth := getNumber(descriptor.Get("MissingWidth")); missingWidth != nil {
+			metrics.defaultWidth = *missingWidth
+		}
+	}
+	return metrics
+}
+
+func (te *TextExtractor) loadCompositeFontMetrics(fontDict *parser.Dictionary) *fontMetrics {
+	descendants, ok := te.resolveObject(fontDict.Get("DescendantFonts")).(*parser.Array)
+	if !ok || descendants.Len() == 0 {
+		return nil
+	}
+	descendant, ok := te.resolveObject(descendants.Get(0)).(*parser.Dictionary)
+	if !ok {
+		return nil
+	}
+
+	metrics := &fontMetrics{
+		widths:       make(map[uint16]float64),
+		defaultWidth: 1000,
+		precise:      true,
+	}
+	if defaultWidth := getNumber(descendant.Get("DW")); defaultWidth != nil {
+		metrics.defaultWidth = *defaultWidth
+	}
+	widths, _ := te.resolveObject(descendant.Get("W")).(*parser.Array)
+	if widths == nil {
+		return metrics
+	}
+
+	for i := 0; i < widths.Len(); {
+		firstObj, ok := widths.Get(i).(*parser.Integer)
+		if !ok {
+			break
+		}
+		first := int(firstObj.Value())
+		i++
+		if i >= widths.Len() {
+			break
+		}
+
+		if explicit, ok := te.resolveObject(widths.Get(i)).(*parser.Array); ok {
+			for offset := 0; offset < explicit.Len(); offset++ {
+				if width := getNumber(explicit.Get(offset)); width != nil && first+offset >= 0 && first+offset <= 65535 {
+					metrics.widths[uint16(first+offset)] = *width
+				}
+			}
+			i++
+			continue
+		}
+
+		lastObj, ok := widths.Get(i).(*parser.Integer)
+		if !ok || i+1 >= widths.Len() {
+			break
+		}
+		width := getNumber(widths.Get(i + 1))
+		if width == nil {
+			break
+		}
+		last := int(lastObj.Value())
+		for glyphID := first; glyphID <= last && glyphID <= 65535; glyphID++ {
+			if glyphID >= 0 {
+				metrics.widths[uint16(glyphID)] = *width
+			}
+		}
+		i += 2
+	}
+	return metrics
+}
+
+func (te *TextExtractor) resolveObject(object parser.PdfObject) parser.PdfObject {
+	if ref, ok := object.(*parser.IndirectReference); ok {
+		resolved, err := te.reader.GetObject(ref.Number)
+		if err != nil {
+			return nil
+		}
+		return resolved
+	}
+	return object
+}

--- a/internal/extractor/font_metrics.go
+++ b/internal/extractor/font_metrics.go
@@ -71,7 +71,7 @@ func (te *TextExtractor) loadSimpleFontMetrics(fontDict *parser.Dictionary) *fon
 	if !ok {
 		return nil
 	}
-	widthsObj := te.resolveObject(fontDict.Get("Widths"))
+	widthsObj := resolveObject(te.reader, fontDict.Get("Widths"))
 	widthsArray, ok := widthsObj.(*parser.Array)
 	if !ok || widthsArray.Len() == 0 {
 		return nil
@@ -89,7 +89,7 @@ func (te *TextExtractor) loadSimpleFontMetrics(fontDict *parser.Dictionary) *fon
 		}
 	}
 
-	if descriptor, ok := te.resolveObject(fontDict.Get("FontDescriptor")).(*parser.Dictionary); ok {
+	if descriptor, ok := resolveObject(te.reader, fontDict.Get("FontDescriptor")).(*parser.Dictionary); ok {
 		if missingWidth := getNumber(descriptor.Get("MissingWidth")); missingWidth != nil {
 			metrics.defaultWidth = *missingWidth
 		}
@@ -98,11 +98,11 @@ func (te *TextExtractor) loadSimpleFontMetrics(fontDict *parser.Dictionary) *fon
 }
 
 func (te *TextExtractor) loadCompositeFontMetrics(fontDict *parser.Dictionary) *fontMetrics {
-	descendants, ok := te.resolveObject(fontDict.Get("DescendantFonts")).(*parser.Array)
+	descendants, ok := resolveObject(te.reader, fontDict.Get("DescendantFonts")).(*parser.Array)
 	if !ok || descendants.Len() == 0 {
 		return nil
 	}
-	descendant, ok := te.resolveObject(descendants.Get(0)).(*parser.Dictionary)
+	descendant, ok := resolveObject(te.reader, descendants.Get(0)).(*parser.Dictionary)
 	if !ok {
 		return nil
 	}
@@ -115,7 +115,7 @@ func (te *TextExtractor) loadCompositeFontMetrics(fontDict *parser.Dictionary) *
 	if defaultWidth := getNumber(descendant.Get("DW")); defaultWidth != nil {
 		metrics.defaultWidth = *defaultWidth
 	}
-	widths, _ := te.resolveObject(descendant.Get("W")).(*parser.Array)
+	widths, _ := resolveObject(te.reader, descendant.Get("W")).(*parser.Array)
 	if widths == nil {
 		return metrics
 	}
@@ -131,7 +131,7 @@ func (te *TextExtractor) loadCompositeFontMetrics(fontDict *parser.Dictionary) *
 			break
 		}
 
-		if explicit, ok := te.resolveObject(widths.Get(i)).(*parser.Array); ok {
+		if explicit, ok := resolveObject(te.reader, widths.Get(i)).(*parser.Array); ok {
 			for offset := 0; offset < explicit.Len(); offset++ {
 				glyphID := first + int64(offset)
 				if width := getNumber(explicit.Get(offset)); width != nil && glyphID >= 0 && glyphID <= 65535 {
@@ -166,15 +166,4 @@ func (te *TextExtractor) loadCompositeFontMetrics(fontDict *parser.Dictionary) *
 		i += 2
 	}
 	return metrics
-}
-
-func (te *TextExtractor) resolveObject(object parser.PdfObject) parser.PdfObject {
-	if ref, ok := object.(*parser.IndirectReference); ok {
-		resolved, err := te.reader.GetObject(ref.Number)
-		if err != nil {
-			return nil
-		}
-		return resolved
-	}
-	return object
 }

--- a/internal/extractor/font_metrics_test.go
+++ b/internal/extractor/font_metrics_test.go
@@ -8,18 +8,61 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLoadCompositeFontMetricsClampsHostileNegativeRange(t *testing.T) {
-	widths := parser.NewArrayFromSlice([]parser.PdfObject{
-		parser.NewInteger(-2_000_000_000),
-		parser.NewInteger(2),
-		parser.NewInteger(500),
-	})
-	descendant := parser.NewDictionary()
-	descendant.Set("W", widths)
-	font := parser.NewDictionary()
-	font.Set("DescendantFonts", parser.NewArrayFromSlice([]parser.PdfObject{descendant}))
+func TestLoadCompositeFontMetricsBoundsWidthDefinitions(t *testing.T) {
+	tests := []struct {
+		name         string
+		widths       []parser.PdfObject
+		defaultWidth int64
+		want         map[uint16]float64
+	}{
+		{
+			name: "hostile negative range",
+			widths: []parser.PdfObject{
+				parser.NewInteger(-2_000_000_000), parser.NewInteger(2), parser.NewInteger(500),
+			},
+			defaultWidth: 750,
+			want:         map[uint16]float64{0: 500, 1: 500, 2: 500},
+		},
+		{
+			name: "hostile upper range",
+			widths: []parser.PdfObject{
+				parser.NewInteger(65_534), parser.NewInteger(2_000_000_000), parser.NewInteger(600),
+			},
+			defaultWidth: 800,
+			want:         map[uint16]float64{65_534: 600, 65_535: 600},
+		},
+		{
+			name: "range outside cid space",
+			widths: []parser.PdfObject{
+				parser.NewInteger(-20), parser.NewInteger(-10), parser.NewInteger(400),
+			},
+			defaultWidth: 900,
+			want:         map[uint16]float64{},
+		},
+		{
+			name: "explicit widths crossing zero",
+			widths: []parser.PdfObject{
+				parser.NewInteger(-1), parser.NewArrayFromSlice([]parser.PdfObject{
+					parser.NewInteger(100), parser.NewInteger(200), parser.NewInteger(300),
+				}),
+			},
+			defaultWidth: 1_000,
+			want:         map[uint16]float64{0: 200, 1: 300},
+		},
+	}
 
-	metrics := (&TextExtractor{}).loadCompositeFontMetrics(font)
-	require.NotNil(t, metrics)
-	assert.Equal(t, map[uint16]float64{0: 500, 1: 500, 2: 500}, metrics.widths)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			descendant := parser.NewDictionary()
+			descendant.Set("DW", parser.NewInteger(test.defaultWidth))
+			descendant.Set("W", parser.NewArrayFromSlice(test.widths))
+			font := parser.NewDictionary()
+			font.Set("DescendantFonts", parser.NewArrayFromSlice([]parser.PdfObject{descendant}))
+
+			metrics := (&TextExtractor{}).loadCompositeFontMetrics(font)
+			require.NotNil(t, metrics)
+			assert.Equal(t, float64(test.defaultWidth), metrics.defaultWidth)
+			assert.Equal(t, test.want, metrics.widths)
+		})
+	}
 }

--- a/internal/extractor/font_metrics_test.go
+++ b/internal/extractor/font_metrics_test.go
@@ -1,0 +1,25 @@
+package extractor
+
+import (
+	"testing"
+
+	"github.com/coregx/gxpdf/internal/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadCompositeFontMetricsClampsHostileNegativeRange(t *testing.T) {
+	widths := parser.NewArrayFromSlice([]parser.PdfObject{
+		parser.NewInteger(-2_000_000_000),
+		parser.NewInteger(2),
+		parser.NewInteger(500),
+	})
+	descendant := parser.NewDictionary()
+	descendant.Set("W", widths)
+	font := parser.NewDictionary()
+	font.Set("DescendantFonts", parser.NewArrayFromSlice([]parser.PdfObject{descendant}))
+
+	metrics := (&TextExtractor{}).loadCompositeFontMetrics(font)
+	require.NotNil(t, metrics)
+	assert.Equal(t, map[uint16]float64{0: 500, 1: 500, 2: 500}, metrics.widths)
+}

--- a/internal/extractor/form_xobject_test.go
+++ b/internal/extractor/form_xobject_test.go
@@ -421,6 +421,7 @@ func TestFormXObject_AppliesPageAndFormTransformsToGlyphGeometry(t *testing.T) {
 	assert.InDelta(t, 6, elements[0].Width, 0.001)
 	assert.InDelta(t, 5, elements[0].Height, 0.001)
 	assert.InDelta(t, 5, elements[0].FontSize, 0.001)
+	assert.True(t, elements[0].preciseWidth)
 
 	assert.Equal(t, "C", elements[1].Text)
 	assert.InDelta(t, 67.5, elements[1].X, 0.001)
@@ -432,6 +433,7 @@ func TestFormXObject_AppliesPageAndFormTransformsToGlyphGeometry(t *testing.T) {
 	assert.InDelta(t, 20, elements[2].Y, 0.001)
 	assert.InDelta(t, 6, elements[2].Width, 0.001)
 	assert.InDelta(t, 10, elements[2].FontSize, 0.001)
+	assert.False(t, elements[2].preciseWidth, "direct-page text must retain legacy width behavior")
 
 	assert.Equal(t, "AB C\nD", AssembleText(elements))
 }

--- a/internal/extractor/form_xobject_test.go
+++ b/internal/extractor/form_xobject_test.go
@@ -244,6 +244,39 @@ func buildNestedXObjectPDF(t *testing.T) []byte {
 	return b.finalize(catalogN)
 }
 
+// buildTransformedGlyphXObjectPDF mimics Quartz-generated financial reports:
+// the page scales a Form XObject, the Form supplies its own matrix, and each
+// glyph is positioned by a nested cm operator while the text matrix stays at
+// the origin. Accurate coordinates therefore require all three transforms.
+func buildTransformedGlyphXObjectPDF(t *testing.T) []byte {
+	t.Helper()
+
+	b := newXObjPDFBuilder(20)
+	fontN := b.addRaw("<< /Type /Font /Subtype /TrueType /BaseFont /Test /FirstChar 65 /LastChar 68 /Widths [600 600 600 600] >>")
+
+	xobjContent := []byte(strings.Join([]string{
+		"q 10 0 0 10 100 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (A) Tj ET Q",
+		"q 10 0 0 10 106 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (B) Tj ET Q",
+		"q 10 0 0 10 115 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (C) Tj ET Q",
+	}, "\n"))
+	xobjN := b.addStream(
+		fmt.Sprintf("/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Matrix [1 0 0 1 20 30] /Resources << /Font << /F1 %d 0 R >> >>", fontN),
+		xobjContent,
+	)
+
+	// The direct page text after Q proves that the Form and graphics state are
+	// restored rather than leaking their scale/translation into the caller.
+	pageContent := []byte("q 0.5 0 0 0.5 0 0 cm /Fm1 Do Q BT /F1 10 Tf 1 0 0 1 10 20 Tm (D) Tj ET")
+	pageContentN := b.addStream("", pageContent)
+	pageN := b.addRaw(fmt.Sprintf(
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 %d 0 R >> /XObject << /Fm1 %d 0 R >> >> /Contents %d 0 R >>",
+		fontN, xobjN, pageContentN,
+	))
+	pagesN := b.addRaw(fmt.Sprintf("<< /Type /Pages /Kids [%d 0 R] /Count 1 >>", pageN))
+	catalogN := b.addRaw(fmt.Sprintf("<< /Type /Catalog /Pages %d 0 R >>", pagesN))
+	return b.finalize(catalogN)
+}
+
 // buildImageXObjectPDF builds a PDF whose XObjects section contains only an
 // Image XObject (Subtype /Image). The extractor must skip it silently.
 //
@@ -372,6 +405,35 @@ func TestFormXObject_SimpleFont_ExtractsText(t *testing.T) {
 	}
 	assert.Equal(t, "Hello World", sb.String(),
 		"Form XObject with simple font must produce correct text")
+}
+
+func TestFormXObject_AppliesPageAndFormTransformsToGlyphGeometry(t *testing.T) {
+	reader := openPDFBytes(t, buildTransformedGlyphXObjectPDF(t))
+	extractor := NewTextExtractor(reader)
+
+	elements, err := extractor.ExtractFromPage(0)
+	require.NoError(t, err)
+	require.Len(t, elements, 3)
+
+	assert.Equal(t, "AB", elements[0].Text)
+	assert.InDelta(t, 60, elements[0].X, 0.001)
+	assert.InDelta(t, 115, elements[0].Y, 0.001)
+	assert.InDelta(t, 6, elements[0].Width, 0.001)
+	assert.InDelta(t, 5, elements[0].Height, 0.001)
+	assert.InDelta(t, 5, elements[0].FontSize, 0.001)
+
+	assert.Equal(t, "C", elements[1].Text)
+	assert.InDelta(t, 67.5, elements[1].X, 0.001)
+	assert.InDelta(t, 115, elements[1].Y, 0.001)
+	assert.InDelta(t, 3, elements[1].Width, 0.001)
+
+	assert.Equal(t, "D", elements[2].Text)
+	assert.InDelta(t, 10, elements[2].X, 0.001)
+	assert.InDelta(t, 20, elements[2].Y, 0.001)
+	assert.InDelta(t, 6, elements[2].Width, 0.001)
+	assert.InDelta(t, 10, elements[2].FontSize, 0.001)
+
+	assert.Equal(t, "AB C\nD", AssembleText(elements))
 }
 
 // ─── Test 2: Type0 CID font inside Form XObject (TCPDF pattern) ──────────────

--- a/internal/extractor/form_xobject_test.go
+++ b/internal/extractor/form_xobject_test.go
@@ -134,6 +134,27 @@ func buildSimpleFontXObjectPDF(t *testing.T) []byte {
 	return b.finalize(catalogN)
 }
 
+// buildUnbalancedRestoreXObjectPDF places an unmatched Q at the start of a
+// Form. PDF Form execution has its own graphics-state stack, so that malformed
+// operator must not consume the page's surrounding q or change later geometry.
+func buildUnbalancedRestoreXObjectPDF(t *testing.T) []byte {
+	t.Helper()
+	b := newXObjPDFBuilder(15)
+	fontN := b.addRaw("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>")
+	xobjN := b.addStream(
+		fmt.Sprintf("/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Resources << /Font << /F1 %d 0 R >> >>", fontN),
+		[]byte("Q BT /F1 1 Tf 0 0 Td (A) Tj ET"),
+	)
+	pageContentN := b.addStream("", []byte("q 2 0 0 2 10 20 cm /TPL1 Do Q BT /F1 10 Tf 10 20 Td (D) Tj ET"))
+	pageN := b.addRaw(fmt.Sprintf(
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 %d 0 R >> /XObject << /TPL1 %d 0 R >> >> /Contents %d 0 R >>",
+		fontN, xobjN, pageContentN,
+	))
+	pagesN := b.addRaw(fmt.Sprintf("<< /Type /Pages /Kids [%d 0 R] /Count 1 >>", pageN))
+	catalogN := b.addRaw(fmt.Sprintf("<< /Type /Catalog /Pages %d 0 R >>", pagesN))
+	return b.finalize(catalogN)
+}
+
 // buildType0XObjectPDF constructs a PDF that mimics the TCPDF Correo Argentino
 // pattern: all text is inside a Form XObject, and the font is Type0 with
 // Identity-H encoding + a ToUnicode CMap using bfrange scalar form.
@@ -436,6 +457,22 @@ func TestFormXObject_AppliesPageAndFormTransformsToGlyphGeometry(t *testing.T) {
 	assert.False(t, elements[2].preciseWidth, "direct-page text must retain legacy width behavior")
 
 	assert.Equal(t, "AB C\nD", AssembleText(elements))
+}
+
+func TestFormXObject_UnmatchedRestoreCannotPopCallerGraphicsState(t *testing.T) {
+	reader := openPDFBytes(t, buildUnbalancedRestoreXObjectPDF(t))
+	extractor := NewTextExtractor(reader)
+
+	elements, err := extractor.ExtractFromPage(0)
+	require.NoError(t, err)
+	require.Len(t, elements, 2)
+
+	assert.Equal(t, "A", elements[0].Text)
+	assert.InDelta(t, 10, elements[0].X, 0.001)
+	assert.InDelta(t, 20, elements[0].Y, 0.001)
+	assert.Equal(t, "D", elements[1].Text)
+	assert.InDelta(t, 10, elements[1].X, 0.001)
+	assert.InDelta(t, 20, elements[1].Y, 0.001)
 }
 
 // ─── Test 2: Type0 CID font inside Form XObject (TCPDF pattern) ──────────────

--- a/internal/extractor/form_xobject_test.go
+++ b/internal/extractor/form_xobject_test.go
@@ -270,6 +270,10 @@ func buildNestedXObjectPDF(t *testing.T) []byte {
 // glyph is positioned by a nested cm operator while the text matrix stays at
 // the origin. Accurate coordinates therefore require all three transforms.
 func buildTransformedGlyphXObjectPDF(t *testing.T) []byte {
+	return buildTransformedGlyphXObjectPDFWithRotation(t, 0)
+}
+
+func buildTransformedGlyphXObjectPDFWithRotation(t *testing.T, rotation int) []byte {
 	t.Helper()
 
 	b := newXObjPDFBuilder(20)
@@ -289,9 +293,13 @@ func buildTransformedGlyphXObjectPDF(t *testing.T) []byte {
 	// restored rather than leaking their scale/translation into the caller.
 	pageContent := []byte("q 0.5 0 0 0.5 0 0 cm /Fm1 Do Q BT /F1 10 Tf 1 0 0 1 10 20 Tm (D) Tj ET")
 	pageContentN := b.addStream("", pageContent)
+	rotationEntry := ""
+	if rotation != 0 {
+		rotationEntry = fmt.Sprintf(" /Rotate %d", rotation)
+	}
 	pageN := b.addRaw(fmt.Sprintf(
-		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 %d 0 R >> /XObject << /Fm1 %d 0 R >> >> /Contents %d 0 R >>",
-		fontN, xobjN, pageContentN,
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]%s /Resources << /Font << /F1 %d 0 R >> /XObject << /Fm1 %d 0 R >> >> /Contents %d 0 R >>",
+		rotationEntry, fontN, xobjN, pageContentN,
 	))
 	pagesN := b.addRaw(fmt.Sprintf("<< /Type /Pages /Kids [%d 0 R] /Count 1 >>", pageN))
 	catalogN := b.addRaw(fmt.Sprintf("<< /Type /Catalog /Pages %d 0 R >>", pagesN))
@@ -429,34 +437,40 @@ func TestFormXObject_SimpleFont_ExtractsText(t *testing.T) {
 }
 
 func TestFormXObject_AppliesPageAndFormTransformsToGlyphGeometry(t *testing.T) {
-	reader := openPDFBytes(t, buildTransformedGlyphXObjectPDF(t))
-	extractor := NewTextExtractor(reader)
+	for _, rotation := range []int{0, 90} {
+		t.Run(fmt.Sprintf("page-rotate-%d", rotation), func(t *testing.T) {
+			reader := openPDFBytes(t, buildTransformedGlyphXObjectPDFWithRotation(t, rotation))
+			extractor := NewTextExtractor(reader)
 
-	elements, err := extractor.ExtractFromPage(0)
-	require.NoError(t, err)
-	require.Len(t, elements, 3)
+			elements, err := extractor.ExtractFromPage(0)
+			require.NoError(t, err)
+			require.Len(t, elements, 3)
 
-	assert.Equal(t, "AB", elements[0].Text)
-	assert.InDelta(t, 60, elements[0].X, 0.001)
-	assert.InDelta(t, 115, elements[0].Y, 0.001)
-	assert.InDelta(t, 6, elements[0].Width, 0.001)
-	assert.InDelta(t, 5, elements[0].Height, 0.001)
-	assert.InDelta(t, 5, elements[0].FontSize, 0.001)
-	assert.True(t, elements[0].preciseWidth)
+			// /Rotate controls page display orientation. Extracted coordinates stay
+			// in PDF page user space and must not disturb Form matrix composition.
+			assert.Equal(t, "AB", elements[0].Text)
+			assert.InDelta(t, 60, elements[0].X, 0.001)
+			assert.InDelta(t, 115, elements[0].Y, 0.001)
+			assert.InDelta(t, 6, elements[0].Width, 0.001)
+			assert.InDelta(t, 5, elements[0].Height, 0.001)
+			assert.InDelta(t, 5, elements[0].FontSize, 0.001)
+			assert.True(t, elements[0].preciseWidth)
 
-	assert.Equal(t, "C", elements[1].Text)
-	assert.InDelta(t, 67.5, elements[1].X, 0.001)
-	assert.InDelta(t, 115, elements[1].Y, 0.001)
-	assert.InDelta(t, 3, elements[1].Width, 0.001)
+			assert.Equal(t, "C", elements[1].Text)
+			assert.InDelta(t, 67.5, elements[1].X, 0.001)
+			assert.InDelta(t, 115, elements[1].Y, 0.001)
+			assert.InDelta(t, 3, elements[1].Width, 0.001)
 
-	assert.Equal(t, "D", elements[2].Text)
-	assert.InDelta(t, 10, elements[2].X, 0.001)
-	assert.InDelta(t, 20, elements[2].Y, 0.001)
-	assert.InDelta(t, 6, elements[2].Width, 0.001)
-	assert.InDelta(t, 10, elements[2].FontSize, 0.001)
-	assert.False(t, elements[2].preciseWidth, "direct-page text must retain legacy width behavior")
+			assert.Equal(t, "D", elements[2].Text)
+			assert.InDelta(t, 10, elements[2].X, 0.001)
+			assert.InDelta(t, 20, elements[2].Y, 0.001)
+			assert.InDelta(t, 6, elements[2].Width, 0.001)
+			assert.InDelta(t, 10, elements[2].FontSize, 0.001)
+			assert.False(t, elements[2].preciseWidth, "direct-page text must retain legacy width behavior")
 
-	assert.Equal(t, "AB C\nD", AssembleText(elements))
+			assert.Equal(t, "AB C\nD", AssembleText(elements))
+		})
+	}
 }
 
 func TestFormXObject_UnmatchedRestoreCannotPopCallerGraphicsState(t *testing.T) {

--- a/internal/extractor/form_xobject_test.go
+++ b/internal/extractor/form_xobject_test.go
@@ -309,6 +309,54 @@ func positionedText(text, operator string) string {
 	return fmt.Sprintf("(%s) Tj", text)
 }
 
+// buildResourceScopedFontsXObjectPDF creates two sibling Forms that both call
+// their font /F1 while defining different encodings and widths for that local
+// name. Decoder and metric caches must not cross the resource boundary.
+func buildResourceScopedFontsXObjectPDF(t *testing.T) []byte {
+	t.Helper()
+	b := newXObjPDFBuilder(20)
+	firstFontN := b.addRaw("<< /Type /Font /Subtype /TrueType /BaseFont /First /FirstChar 65 /LastChar 65 /Widths [600] /Encoding /WinAnsiEncoding >>")
+	secondFontN := b.addRaw("<< /Type /Font /Subtype /TrueType /BaseFont /Second /FirstChar 65 /LastChar 65 /Widths [1000] /Encoding << /BaseEncoding /WinAnsiEncoding /Differences [65 /Z] >> >>")
+	firstFormN := b.addStream(
+		fmt.Sprintf("/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Resources << /Font << /F1 %d 0 R >> >>", firstFontN),
+		[]byte("q 10 0 0 10 0 100 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (A) Tj ET Q"),
+	)
+	secondFormN := b.addStream(
+		fmt.Sprintf("/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Resources << /Font << /F1 %d 0 R >> >>", secondFontN),
+		[]byte("q 10 0 0 10 20 100 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (A) Tj ET Q"),
+	)
+	pageContentN := b.addStream("", []byte("/First Do /Second Do"))
+	pageN := b.addRaw(fmt.Sprintf(
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /First %d 0 R /Second %d 0 R >> >> /Contents %d 0 R >>",
+		firstFormN, secondFormN, pageContentN,
+	))
+	pagesN := b.addRaw(fmt.Sprintf("<< /Type /Pages /Kids [%d 0 R] /Count 1 >>", pageN))
+	catalogN := b.addRaw(fmt.Sprintf("<< /Type /Catalog /Pages %d 0 R >>", pagesN))
+	return b.finalize(catalogN)
+}
+
+// buildFormTextStateIsolationPDF changes every tracked text-state parameter in
+// a Form, then emits caller text without setting those parameters again.
+func buildFormTextStateIsolationPDF(t *testing.T) []byte {
+	t.Helper()
+	b := newXObjPDFBuilder(20)
+	pageFontN := b.addRaw("<< /Type /Font /Subtype /TrueType /BaseFont /Page /FirstChar 68 /LastChar 68 /Widths [600] >>")
+	formFontN := b.addRaw("<< /Type /Font /Subtype /TrueType /BaseFont /Form /FirstChar 65 /LastChar 65 /Widths [600] >>")
+	formN := b.addStream(
+		fmt.Sprintf("/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Resources << /Font << /FForm %d 0 R >> >>", formFontN),
+		[]byte("BT /FForm 1 Tf 9 Tc 8 Tw 50 Tz 7 TL 3 Ts 1 0 0 1 0 100 Tm (A) Tj ET"),
+	)
+	pageContent := []byte("BT /FPage 10 Tf 1 Tc 2 Tw 80 Tz 14 TL 4 Ts ET /Fm Do BT 1 0 0 1 20 20 Tm (D) Tj ET")
+	pageContentN := b.addStream("", pageContent)
+	pageN := b.addRaw(fmt.Sprintf(
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /FPage %d 0 R >> /XObject << /Fm %d 0 R >> >> /Contents %d 0 R >>",
+		pageFontN, formN, pageContentN,
+	))
+	pagesN := b.addRaw(fmt.Sprintf("<< /Type /Pages /Kids [%d 0 R] /Count 1 >>", pageN))
+	catalogN := b.addRaw(fmt.Sprintf("<< /Type /Catalog /Pages %d 0 R >>", pagesN))
+	return b.finalize(catalogN)
+}
+
 // buildImageXObjectPDF builds a PDF whose XObjects section contains only an
 // Image XObject (Subtype /Image). The extractor must skip it silently.
 //
@@ -476,6 +524,92 @@ func TestFormXObject_AppliesPageAndFormTransformsToGlyphGeometry(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestFormXObject_FontCachesAreScopedToResources(t *testing.T) {
+	reader := openPDFBytes(t, buildResourceScopedFontsXObjectPDF(t))
+	extractor := NewTextExtractor(reader)
+
+	elements, err := extractor.ExtractFromPage(0)
+	require.NoError(t, err)
+	require.Len(t, elements, 2)
+
+	assert.Equal(t, "A", elements[0].Text)
+	assert.InDelta(t, 6, elements[0].Width, 0.001)
+	assert.Equal(t, "Z", elements[1].Text)
+	assert.InDelta(t, 10, elements[1].Width, 0.001)
+}
+
+func TestFormXObject_RestoresCallerTextState(t *testing.T) {
+	reader := openPDFBytes(t, buildFormTextStateIsolationPDF(t))
+	extractor := NewTextExtractor(reader)
+
+	elements, err := extractor.ExtractFromPage(0)
+	require.NoError(t, err)
+	require.Len(t, elements, 2)
+
+	assert.Equal(t, "D", elements[1].Text)
+	assert.Equal(t, "FPage", elements[1].FontName)
+	assert.InDelta(t, 10, elements[1].FontSize, 0.001)
+	assert.InDelta(t, 4.8, elements[1].Width, 0.001)
+	assert.Equal(t, "FPage", extractor.textState.FontName)
+	assert.InDelta(t, 10, extractor.textState.FontSize, 0.001)
+	assert.InDelta(t, 1, extractor.textState.CharSpace, 0.001)
+	assert.InDelta(t, 2, extractor.textState.WordSpace, 0.001)
+	assert.InDelta(t, 80, extractor.textState.HorizScale, 0.001)
+	assert.InDelta(t, 14, extractor.textState.Leading, 0.001)
+	assert.InDelta(t, 4, extractor.textState.Rise, 0.001)
+}
+
+func TestGraphicsStateRestoresTextParametersButNotTextMatrix(t *testing.T) {
+	extractor := NewTextExtractor(nil)
+	extractor.textState.SetFont("CallerFont", 12)
+	extractor.textState.CharSpace = 1
+	extractor.textState.WordSpace = 2
+	extractor.textState.HorizScale = 80
+	extractor.textState.Leading = 14
+	extractor.textState.Rise = 4
+	extractor.processOperator(&Operator{Name: "q"})
+
+	extractor.textState.SetFont("NestedFont", 1)
+	extractor.textState.CharSpace = 9
+	extractor.textState.WordSpace = 8
+	extractor.textState.HorizScale = 50
+	extractor.textState.Leading = 7
+	extractor.textState.Rise = 3
+	extractor.textState.SetTextMatrix(1, 0, 0, 1, 30, 40)
+	extractor.processOperator(&Operator{Name: "Q"})
+
+	assert.Equal(t, "CallerFont", extractor.textState.FontName)
+	assert.InDelta(t, 12, extractor.textState.FontSize, 0.001)
+	assert.InDelta(t, 1, extractor.textState.CharSpace, 0.001)
+	assert.InDelta(t, 2, extractor.textState.WordSpace, 0.001)
+	assert.InDelta(t, 80, extractor.textState.HorizScale, 0.001)
+	assert.InDelta(t, 14, extractor.textState.Leading, 0.001)
+	assert.InDelta(t, 4, extractor.textState.Rise, 0.001)
+	assert.InDelta(t, 30, extractor.textState.CurrentX, 0.001, "q/Q must not restore the text matrix")
+	assert.InDelta(t, 40, extractor.textState.CurrentY, 0.001, "q/Q must not restore the text matrix")
+}
+
+func TestPositionedTJAdjustmentHonorsHorizontalScaling(t *testing.T) {
+	extractor := NewTextExtractor(nil)
+	extractor.xobjectDepth = 1
+	extractor.ctm = Scaling(10, 10)
+	extractor.textState.SetFont("F1", 1)
+	extractor.textState.HorizScale = 50
+	extractor.fontMetrics["F1"] = &fontMetrics{
+		widths:       map[uint16]float64{65: 600, 66: 600},
+		defaultWidth: 600,
+		precise:      true,
+	}
+	items := parser.NewArrayFromSlice([]parser.PdfObject{
+		parser.NewString("A"), parser.NewInteger(-100), parser.NewString("B"),
+	})
+
+	extractor.processTextArray(items)
+	require.Len(t, extractor.elements, 2)
+	assert.InDelta(t, 0, extractor.elements[0].X, 0.001)
+	assert.InDelta(t, 3.5, extractor.elements[1].X, 0.001)
 }
 
 func TestFormXObject_UnmatchedRestoreCannotPopCallerGraphicsState(t *testing.T) {

--- a/internal/extractor/form_xobject_test.go
+++ b/internal/extractor/form_xobject_test.go
@@ -269,20 +269,16 @@ func buildNestedXObjectPDF(t *testing.T) []byte {
 // the page scales a Form XObject, the Form supplies its own matrix, and each
 // glyph is positioned by a nested cm operator while the text matrix stays at
 // the origin. Accurate coordinates therefore require all three transforms.
-func buildTransformedGlyphXObjectPDF(t *testing.T) []byte {
-	return buildTransformedGlyphXObjectPDFWithRotation(t, 0)
-}
-
-func buildTransformedGlyphXObjectPDFWithRotation(t *testing.T, rotation int) []byte {
+func buildTransformedGlyphXObjectPDF(t *testing.T, rotation int, textOperator string) []byte {
 	t.Helper()
 
 	b := newXObjPDFBuilder(20)
 	fontN := b.addRaw("<< /Type /Font /Subtype /TrueType /BaseFont /Test /FirstChar 65 /LastChar 68 /Widths [600 600 600 600] >>")
 
 	xobjContent := []byte(strings.Join([]string{
-		"q 10 0 0 10 100 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (A) Tj ET Q",
-		"q 10 0 0 10 106 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (B) Tj ET Q",
-		"q 10 0 0 10 115 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (C) Tj ET Q",
+		fmt.Sprintf("q 10 0 0 10 100 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm %s ET Q", positionedText("A", textOperator)),
+		fmt.Sprintf("q 10 0 0 10 106 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm %s ET Q", positionedText("B", textOperator)),
+		fmt.Sprintf("q 10 0 0 10 115 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm %s ET Q", positionedText("C", textOperator)),
 	}, "\n"))
 	xobjN := b.addStream(
 		fmt.Sprintf("/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Matrix [1 0 0 1 20 30] /Resources << /Font << /F1 %d 0 R >> >>", fontN),
@@ -304,6 +300,13 @@ func buildTransformedGlyphXObjectPDFWithRotation(t *testing.T, rotation int) []b
 	pagesN := b.addRaw(fmt.Sprintf("<< /Type /Pages /Kids [%d 0 R] /Count 1 >>", pageN))
 	catalogN := b.addRaw(fmt.Sprintf("<< /Type /Catalog /Pages %d 0 R >>", pagesN))
 	return b.finalize(catalogN)
+}
+
+func positionedText(text, operator string) string {
+	if operator == "TJ" {
+		return fmt.Sprintf("[(%s)] TJ", text)
+	}
+	return fmt.Sprintf("(%s) Tj", text)
 }
 
 // buildImageXObjectPDF builds a PDF whose XObjects section contains only an
@@ -437,39 +440,41 @@ func TestFormXObject_SimpleFont_ExtractsText(t *testing.T) {
 }
 
 func TestFormXObject_AppliesPageAndFormTransformsToGlyphGeometry(t *testing.T) {
-	for _, rotation := range []int{0, 90} {
-		t.Run(fmt.Sprintf("page-rotate-%d", rotation), func(t *testing.T) {
-			reader := openPDFBytes(t, buildTransformedGlyphXObjectPDFWithRotation(t, rotation))
-			extractor := NewTextExtractor(reader)
+	for _, textOperator := range []string{"Tj", "TJ"} {
+		for _, rotation := range []int{0, 90} {
+			t.Run(fmt.Sprintf("%s/page-rotate-%d", textOperator, rotation), func(t *testing.T) {
+				reader := openPDFBytes(t, buildTransformedGlyphXObjectPDF(t, rotation, textOperator))
+				extractor := NewTextExtractor(reader)
 
-			elements, err := extractor.ExtractFromPage(0)
-			require.NoError(t, err)
-			require.Len(t, elements, 3)
+				elements, err := extractor.ExtractFromPage(0)
+				require.NoError(t, err)
+				require.Len(t, elements, 3)
 
-			// /Rotate controls page display orientation. Extracted coordinates stay
-			// in PDF page user space and must not disturb Form matrix composition.
-			assert.Equal(t, "AB", elements[0].Text)
-			assert.InDelta(t, 60, elements[0].X, 0.001)
-			assert.InDelta(t, 115, elements[0].Y, 0.001)
-			assert.InDelta(t, 6, elements[0].Width, 0.001)
-			assert.InDelta(t, 5, elements[0].Height, 0.001)
-			assert.InDelta(t, 5, elements[0].FontSize, 0.001)
-			assert.True(t, elements[0].preciseWidth)
+				// /Rotate controls page display orientation. Extracted coordinates stay
+				// in PDF page user space and must not disturb Form matrix composition.
+				assert.Equal(t, "AB", elements[0].Text)
+				assert.InDelta(t, 60, elements[0].X, 0.001)
+				assert.InDelta(t, 115, elements[0].Y, 0.001)
+				assert.InDelta(t, 6, elements[0].Width, 0.001)
+				assert.InDelta(t, 5, elements[0].Height, 0.001)
+				assert.InDelta(t, 5, elements[0].FontSize, 0.001)
+				assert.True(t, elements[0].preciseWidth)
 
-			assert.Equal(t, "C", elements[1].Text)
-			assert.InDelta(t, 67.5, elements[1].X, 0.001)
-			assert.InDelta(t, 115, elements[1].Y, 0.001)
-			assert.InDelta(t, 3, elements[1].Width, 0.001)
+				assert.Equal(t, "C", elements[1].Text)
+				assert.InDelta(t, 67.5, elements[1].X, 0.001)
+				assert.InDelta(t, 115, elements[1].Y, 0.001)
+				assert.InDelta(t, 3, elements[1].Width, 0.001)
 
-			assert.Equal(t, "D", elements[2].Text)
-			assert.InDelta(t, 10, elements[2].X, 0.001)
-			assert.InDelta(t, 20, elements[2].Y, 0.001)
-			assert.InDelta(t, 6, elements[2].Width, 0.001)
-			assert.InDelta(t, 10, elements[2].FontSize, 0.001)
-			assert.False(t, elements[2].preciseWidth, "direct-page text must retain legacy width behavior")
+				assert.Equal(t, "D", elements[2].Text)
+				assert.InDelta(t, 10, elements[2].X, 0.001)
+				assert.InDelta(t, 20, elements[2].Y, 0.001)
+				assert.InDelta(t, 6, elements[2].Width, 0.001)
+				assert.InDelta(t, 10, elements[2].FontSize, 0.001)
+				assert.False(t, elements[2].preciseWidth, "direct-page text must retain legacy width behavior")
 
-			assert.Equal(t, "AB C\nD", AssembleText(elements))
-		})
+				assert.Equal(t, "AB C\nD", AssembleText(elements))
+			})
+		}
 	}
 }
 

--- a/internal/extractor/object_resolver.go
+++ b/internal/extractor/object_resolver.go
@@ -1,0 +1,18 @@
+package extractor
+
+import "github.com/coregx/gxpdf/internal/parser"
+
+// resolveObject follows a single indirect reference using the reader's object
+// table. Non-reference objects are returned as-is. It returns nil when the
+// referenced object cannot be resolved.
+func resolveObject(reader *parser.Reader, object parser.PdfObject) parser.PdfObject {
+	reference, ok := object.(*parser.IndirectReference)
+	if !ok {
+		return object
+	}
+	resolved, err := reader.GetObject(reference.Number)
+	if err != nil {
+		return nil
+	}
+	return resolved
+}

--- a/internal/extractor/text_element.go
+++ b/internal/extractor/text_element.go
@@ -30,6 +30,11 @@ type TextElement struct {
 	Height   float64 // Height of text (in points)
 	FontName string  // Font name (e.g., "/F1", "/Helvetica")
 	FontSize float64 // Font size in points
+
+	// preciseWidth records whether Width came from the PDF font metrics rather
+	// than the legacy 0.6-em estimate. It intentionally remains internal: it is
+	// extraction metadata used to distinguish glyph kerning from word gaps.
+	preciseWidth bool
 }
 
 // NewTextElement creates a new TextElement with the given properties.

--- a/internal/extractor/text_extractor.go
+++ b/internal/extractor/text_extractor.go
@@ -826,7 +826,10 @@ func (te *TextExtractor) processFormXObject(xobjName string) {
 	// Push current resources and switch to XObject's resources (if present)
 	savedResources := te.pageResources
 	savedCTM := te.ctm
-	savedGraphicsDepth := len(te.graphicsStateStack)
+	// Form graphics state is isolated from its caller. Malformed content with
+	// an unmatched Q must not pop a q that belongs to the page or parent Form.
+	savedGraphicsStateStack := te.graphicsStateStack
+	te.graphicsStateStack = nil
 	te.resourceStack = append(te.resourceStack, savedResources)
 	te.xobjectDepth++
 
@@ -850,7 +853,7 @@ func (te *TextExtractor) processFormXObject(xobjName string) {
 	// Restore saved resources and depth counter
 	te.xobjectDepth--
 	te.ctm = savedCTM
-	te.graphicsStateStack = te.graphicsStateStack[:savedGraphicsDepth]
+	te.graphicsStateStack = savedGraphicsStateStack
 	if len(te.resourceStack) > 0 {
 		te.pageResources = te.resourceStack[len(te.resourceStack)-1]
 		te.resourceStack = te.resourceStack[:len(te.resourceStack)-1]

--- a/internal/extractor/text_extractor.go
+++ b/internal/extractor/text_extractor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"strings"
 
 	"github.com/coregx/gxpdf/internal/parser"
@@ -35,6 +36,18 @@ const glyphMergeGapFactor = 1.5
 // as a word boundary and receives a space.
 const wordSpaceGapFactor = 1.0
 
+// preciseGlyphGapFactor is used when the PDF provides authoritative font
+// widths. Exact widths let us preserve real word gaps without the generous
+// tolerance required by the legacy estimated-width path.
+const preciseGlyphGapFactor = 0.2
+
+// positionedGlyphFontSizeLimit identifies the Form-XObject pattern emitted by
+// Quartz and similar generators: every glyph uses a unit-sized font and a cm
+// matrix supplies the actual size and position. Direct-page/larger text keeps
+// the established raw-coordinate behavior until gxpdf's graphics and lattice
+// coordinate paths can migrate together without changing existing tables.
+const positionedGlyphFontSizeLimit = 2.0
+
 // maxXObjectDepth limits Form XObject recursion to prevent infinite loops.
 //
 // The PDF specification does not forbid cyclic XObject references, so we
@@ -63,7 +76,11 @@ type TextExtractor struct {
 	textState     *TextState
 	elements      []*TextElement
 	fontDecoders  map[string]*FontDecoder // fontName -> FontDecoder
+	fontMetrics   map[string]*fontMetrics // fontName -> glyph widths
 	pageResources *parser.Dictionary      // Current page resources
+	ctm           Matrix                  // Current transformation matrix
+
+	graphicsStateStack []textExtractorGraphicsState
 
 	// resourceStack holds the saved resource context across Form XObject calls.
 	// Each Do operator pushes the current resources; on return they are restored.
@@ -74,6 +91,10 @@ type TextExtractor struct {
 	xobjectDepth int
 }
 
+type textExtractorGraphicsState struct {
+	ctm Matrix
+}
+
 // NewTextExtractor creates a new TextExtractor for the given PDF reader.
 func NewTextExtractor(reader *parser.Reader) *TextExtractor {
 	return &TextExtractor{
@@ -81,6 +102,8 @@ func NewTextExtractor(reader *parser.Reader) *TextExtractor {
 		textState:    NewTextState(),
 		elements:     []*TextElement{},
 		fontDecoders: make(map[string]*FontDecoder),
+		fontMetrics:  make(map[string]*fontMetrics),
+		ctm:          Identity(),
 	}
 }
 
@@ -94,6 +117,9 @@ func (te *TextExtractor) ExtractFromPage(pageNum int) ([]*TextElement, error) {
 	te.elements = []*TextElement{}
 	te.textState = NewTextState()
 	te.fontDecoders = make(map[string]*FontDecoder)
+	te.fontMetrics = make(map[string]*fontMetrics)
+	te.ctm = Identity()
+	te.graphicsStateStack = nil
 
 	// Get page
 	page, err := te.reader.GetPage(pageNum)
@@ -176,13 +202,14 @@ func mergeAdjacentElements(elements []*TextElement) []*TextElement {
 		if canMerge(current, next) {
 			// Extend current element: append text and widen bounding box.
 			current = &TextElement{
-				Text:     current.Text + next.Text,
-				X:        current.X,
-				Y:        current.Y,
-				Width:    (next.X + next.Width) - current.X,
-				Height:   current.Height,
-				FontName: current.FontName,
-				FontSize: current.FontSize,
+				Text:         current.Text + next.Text,
+				X:            current.X,
+				Y:            current.Y,
+				Width:        (next.X + next.Width) - current.X,
+				Height:       current.Height,
+				FontName:     current.FontName,
+				FontSize:     current.FontSize,
+				preciseWidth: current.preciseWidth && next.preciseWidth,
 			}
 		} else {
 			// Word boundary — commit the current run and start a new one.
@@ -246,7 +273,11 @@ func canMerge(a, b *TextElement) bool {
 	}
 
 	// Positive gap: merge only if the gap is within the intra-word threshold.
-	threshold := a.FontSize * glyphMergeGapFactor
+	thresholdFactor := glyphMergeGapFactor
+	if a.preciseWidth && b.preciseWidth {
+		thresholdFactor = preciseGlyphGapFactor
+	}
+	threshold := a.FontSize * thresholdFactor
 	return gap <= threshold
 }
 
@@ -290,7 +321,11 @@ func AssembleText(elements []*TextElement) string {
 
 		// Same line: decide whether a space is needed.
 		gap := curr.X - (prev.X + prev.Width)
-		if gap > prev.FontSize*wordSpaceGapFactor {
+		gapFactor := wordSpaceGapFactor
+		if prev.preciseWidth && curr.preciseWidth {
+			gapFactor = preciseGlyphGapFactor
+		}
+		if gap > prev.FontSize*gapFactor {
 			sb.WriteByte(' ')
 		}
 		sb.WriteString(curr.Text)
@@ -466,6 +501,33 @@ func (b *bytesReaderCloser) Close() error {
 //nolint:cyclop,funlen,gocognit,gocyclo // Text operator processing inherently requires many cases
 func (te *TextExtractor) processOperator(op *Operator) {
 	switch op.Name {
+	// Graphics state operators (Section 8.4.2). Text coordinates are expressed
+	// in the current user space, so page/Form transformations must be applied.
+	case "q":
+		te.graphicsStateStack = append(te.graphicsStateStack, textExtractorGraphicsState{
+			ctm: te.ctm,
+		})
+
+	case "Q":
+		if n := len(te.graphicsStateStack); n > 0 {
+			saved := te.graphicsStateStack[n-1]
+			te.graphicsStateStack = te.graphicsStateStack[:n-1]
+			te.ctm = saved.ctm
+		}
+
+	case "cm":
+		if len(op.Operands) >= 6 {
+			values := [6]*float64{}
+			for i := range values {
+				values[i] = getNumber(op.Operands[i])
+			}
+			if values[0] != nil && values[1] != nil && values[2] != nil &&
+				values[3] != nil && values[4] != nil && values[5] != nil {
+				operand := NewMatrix(*values[0], *values[1], *values[2], *values[3], *values[4], *values[5])
+				te.ctm = te.ctm.Multiply(operand)
+			}
+		}
+
 	// Text object delimiters (Section 9.4.1)
 	case "BT": // Begin text
 		te.textState.Reset()
@@ -621,22 +683,70 @@ func (te *TextExtractor) addTextBytes(glyphBytes []byte) {
 	// Decode glyph bytes to Unicode text
 	decodedText := te.decodeTextBytes(glyphBytes)
 
-	// Get current position from text matrix
-	x := te.textState.CurrentX
-	y := te.textState.CurrentY
-
-	// Estimate width (simple heuristic - will be improved with font metrics in Phase 3)
-	// Use decoded text length for more accurate width calculation
-	charWidth := te.textState.FontSize * 0.6 * (te.textState.HorizScale / 100.0)
-	width := float64(len(decodedText)) * charWidth
-	height := te.textState.FontSize
+	advance, width, precise := te.measureGlyphBytes(glyphBytes)
+	positionedFormGeometry := te.usesPositionedFormGeometry()
+	if !positionedFormGeometry {
+		width = float64(len(decodedText)) * te.textState.FontSize * 0.6 * (te.textState.HorizScale / 100.0)
+		advance, precise = width, false
+	}
+	x, y := te.textState.CurrentX, te.textState.CurrentY
+	height, effectiveFontSize := te.textState.FontSize, te.textState.FontSize
+	if positionedFormGeometry {
+		x, y, width, height, effectiveFontSize = te.transformedTextBounds(width)
+	}
 
 	// Create text element with decoded text
-	elem := NewTextElement(decodedText, x, y, width, height, te.textState.FontName, te.textState.FontSize)
+	elem := NewTextElement(decodedText, x, y, width, height, te.textState.FontName, effectiveFontSize)
+	elem.preciseWidth = precise
 	te.elements = append(te.elements, elem)
 
 	// Advance text position
-	te.textState.AdvanceX(width)
+	te.textState.AdvanceX(advance)
+}
+
+// transformedTextBounds maps the text-space bounding box through the text
+// matrix and current transformation matrix and returns its axis-aligned bounds.
+func (te *TextExtractor) transformedTextBounds(width float64) (float64, float64, float64, float64, float64) {
+	// Existing direct-page extraction intentionally remains in raw text space
+	// for compatibility with the lattice coordinate normalizer. Form XObjects,
+	// however, cannot be positioned without inheriting the caller CTM and their
+	// own /Matrix, so apply the accumulated CTM while recursing into a Form.
+	coordinateMatrix := Identity()
+	if te.usesPositionedFormGeometry() {
+		coordinateMatrix = te.ctm
+	}
+	bottom := te.textState.Rise
+	top := bottom + te.textState.FontSize
+	points := [4][2]float64{{0, bottom}, {width, bottom}, {0, top}, {width, top}}
+
+	minX, minY := math.Inf(1), math.Inf(1)
+	maxX, maxY := math.Inf(-1), math.Inf(-1)
+	for _, point := range points {
+		tx, ty := te.textState.Tm.Transform(point[0], point[1])
+		x, y := coordinateMatrix.Transform(tx, ty)
+		minX = math.Min(minX, x)
+		minY = math.Min(minY, y)
+		maxX = math.Max(maxX, x)
+		maxY = math.Max(maxY, y)
+	}
+
+	baseX, baseY := te.textState.Tm.Transform(0, bottom)
+	topX, topY := te.textState.Tm.Transform(0, top)
+	baseX, baseY = coordinateMatrix.Transform(baseX, baseY)
+	topX, topY = coordinateMatrix.Transform(topX, topY)
+	effectiveFontSize := math.Hypot(topX-baseX, topY-baseY)
+
+	return minX, minY, maxX - minX, maxY - minY, effectiveFontSize
+}
+
+func (te *TextExtractor) usesPositionedFormGeometry() bool {
+	if te.xobjectDepth == 0 || te.textState.FontSize <= 0 {
+		return false
+	}
+	baseX, baseY := te.textState.Tm.Transform(0, te.textState.Rise)
+	topX, topY := te.textState.Tm.Transform(0, te.textState.Rise+te.textState.FontSize)
+	rawTextSize := math.Hypot(topX-baseX, topY-baseY)
+	return rawTextSize > 0 && rawTextSize <= positionedGlyphFontSizeLimit
 }
 
 // processTextArray processes a TJ array with positioning adjustments.
@@ -717,12 +827,17 @@ func (te *TextExtractor) processFormXObject(xobjName string) {
 
 	// Push current resources and switch to XObject's resources (if present)
 	savedResources := te.pageResources
+	savedCTM := te.ctm
+	savedGraphicsDepth := len(te.graphicsStateStack)
 	te.resourceStack = append(te.resourceStack, savedResources)
 	te.xobjectDepth++
 
 	xobjResources := te.getXObjectResources(xobjectStream)
 	if xobjResources != nil {
 		te.pageResources = xobjResources
+	}
+	if formMatrix, ok := te.getFormMatrix(xobjectStream); ok {
+		te.ctm = te.ctm.Multiply(formMatrix)
 	}
 
 	// Parse and process the XObject's content stream
@@ -736,12 +851,39 @@ func (te *TextExtractor) processFormXObject(xobjName string) {
 
 	// Restore saved resources and depth counter
 	te.xobjectDepth--
+	te.ctm = savedCTM
+	te.graphicsStateStack = te.graphicsStateStack[:savedGraphicsDepth]
 	if len(te.resourceStack) > 0 {
 		te.pageResources = te.resourceStack[len(te.resourceStack)-1]
 		te.resourceStack = te.resourceStack[:len(te.resourceStack)-1]
 	} else {
 		te.pageResources = savedResources
 	}
+}
+
+// getFormMatrix resolves a Form XObject's optional /Matrix entry.
+func (te *TextExtractor) getFormMatrix(stream *parser.Stream) (Matrix, bool) {
+	matrixObj := stream.Dictionary().Get("Matrix")
+	if ref, ok := matrixObj.(*parser.IndirectReference); ok {
+		resolved, err := te.reader.GetObject(ref.Number)
+		if err != nil {
+			return Matrix{}, false
+		}
+		matrixObj = resolved
+	}
+	arr, ok := matrixObj.(*parser.Array)
+	if !ok || arr.Len() != 6 {
+		return Matrix{}, false
+	}
+	values := [6]float64{}
+	for i := range values {
+		num := getNumber(arr.Get(i))
+		if num == nil {
+			return Matrix{}, false
+		}
+		values[i] = *num
+	}
+	return NewMatrix(values[0], values[1], values[2], values[3], values[4], values[5]), true
 }
 
 // resolveXObject looks up a named XObject from the current pageResources and
@@ -924,6 +1066,10 @@ func (te *TextExtractor) loadFontDecoder(fontName string) {
 		return
 	}
 
+	// Load widths alongside the decoder so positioned glyphs receive accurate
+	// bounds and word-gap detection can use a conservative threshold.
+	te.fontMetrics[fontName] = te.loadFontMetrics(fontDict)
+
 	// Extract encoding name AND Differences array
 	encodingName := ""
 	var differences map[uint16]string
@@ -962,7 +1108,7 @@ func (te *TextExtractor) loadFontDecoder(fontName string) {
 	isType0 := false
 	if subtypeObj := fontDict.Get("Subtype"); subtypeObj != nil {
 		if subtypeName, ok := subtypeObj.(*parser.Name); ok {
-			isType0 = subtypeName.Value() == "Type0"
+			isType0 = subtypeName.Value() == type0FontSubtype
 		}
 	}
 

--- a/internal/extractor/text_extractor.go
+++ b/internal/extractor/text_extractor.go
@@ -710,11 +710,9 @@ func (te *TextExtractor) transformedTextBounds(width float64) (float64, float64,
 	// Existing direct-page extraction intentionally remains in raw text space
 	// for compatibility with the lattice coordinate normalizer. Form XObjects,
 	// however, cannot be positioned without inheriting the caller CTM and their
-	// own /Matrix, so apply the accumulated CTM while recursing into a Form.
-	coordinateMatrix := Identity()
-	if te.usesPositionedFormGeometry() {
-		coordinateMatrix = te.ctm
-	}
+	// own /Matrix. The caller invokes this function only for that positioned
+	// Form path, so the accumulated CTM is always authoritative here.
+	coordinateMatrix := te.ctm
 	bottom := te.textState.Rise
 	top := bottom + te.textState.FontSize
 	points := [4][2]float64{{0, bottom}, {width, bottom}, {0, top}, {width, top}}

--- a/internal/extractor/text_extractor.go
+++ b/internal/extractor/text_extractor.go
@@ -92,7 +92,38 @@ type TextExtractor struct {
 }
 
 type textExtractorGraphicsState struct {
-	ctm Matrix
+	ctm        Matrix
+	fontName   string
+	fontSize   float64
+	charSpace  float64
+	wordSpace  float64
+	horizScale float64
+	leading    float64
+	rise       float64
+}
+
+func (te *TextExtractor) currentGraphicsState() textExtractorGraphicsState {
+	return textExtractorGraphicsState{
+		ctm:        te.ctm,
+		fontName:   te.textState.FontName,
+		fontSize:   te.textState.FontSize,
+		charSpace:  te.textState.CharSpace,
+		wordSpace:  te.textState.WordSpace,
+		horizScale: te.textState.HorizScale,
+		leading:    te.textState.Leading,
+		rise:       te.textState.Rise,
+	}
+}
+
+func (te *TextExtractor) restoreGraphicsState(state textExtractorGraphicsState) {
+	te.ctm = state.ctm
+	te.textState.FontName = state.fontName
+	te.textState.FontSize = state.fontSize
+	te.textState.CharSpace = state.charSpace
+	te.textState.WordSpace = state.wordSpace
+	te.textState.HorizScale = state.horizScale
+	te.textState.Leading = state.leading
+	te.textState.Rise = state.rise
 }
 
 // NewTextExtractor creates a new TextExtractor for the given PDF reader.
@@ -504,15 +535,13 @@ func (te *TextExtractor) processOperator(op *Operator) {
 	// Graphics state operators (Section 8.4.2). Text coordinates are expressed
 	// in the current user space, so page/Form transformations must be applied.
 	case "q":
-		te.graphicsStateStack = append(te.graphicsStateStack, textExtractorGraphicsState{
-			ctm: te.ctm,
-		})
+		te.graphicsStateStack = append(te.graphicsStateStack, te.currentGraphicsState())
 
 	case "Q":
 		if n := len(te.graphicsStateStack); n > 0 {
 			saved := te.graphicsStateStack[n-1]
 			te.graphicsStateStack = te.graphicsStateStack[:n-1]
-			te.ctm = saved.ctm
+			te.restoreGraphicsState(saved)
 		}
 
 	case "cm":
@@ -773,7 +802,7 @@ func (te *TextExtractor) processTextArray(arr *parser.Array) {
 			if num := getNumber(obj); num != nil {
 				// Negative values move forward, positive values move backward
 				// The unit is 1/1000 of a text space unit
-				adjustment := -*num / 1000.0 * te.textState.FontSize
+				adjustment := -*num / 1000.0 * te.textState.FontSize * (te.textState.HorizScale / 100.0)
 				te.textState.AdvanceX(adjustment)
 			}
 		}
@@ -825,7 +854,9 @@ func (te *TextExtractor) processFormXObject(xobjName string) {
 
 	// Push current resources and switch to XObject's resources (if present)
 	savedResources := te.pageResources
-	savedCTM := te.ctm
+	savedGraphicsState := te.currentGraphicsState()
+	savedFontDecoders := te.fontDecoders
+	savedFontMetrics := te.fontMetrics
 	// Form graphics state is isolated from its caller. Malformed content with
 	// an unmatched Q must not pop a q that belongs to the page or parent Form.
 	savedGraphicsStateStack := te.graphicsStateStack
@@ -836,6 +867,11 @@ func (te *TextExtractor) processFormXObject(xobjName string) {
 	xobjResources := te.getXObjectResources(xobjectStream)
 	if xobjResources != nil {
 		te.pageResources = xobjResources
+		// Resource names are local to their dictionary. A page and two Forms may
+		// all define /F1 as different fonts, so decoder and metric caches must
+		// follow the same scope as pageResources.
+		te.fontDecoders = make(map[string]*FontDecoder)
+		te.fontMetrics = make(map[string]*fontMetrics)
 	}
 	if formMatrix, ok := te.getFormMatrix(xobjectStream); ok {
 		te.ctm = te.ctm.Multiply(formMatrix)
@@ -852,8 +888,12 @@ func (te *TextExtractor) processFormXObject(xobjName string) {
 
 	// Restore saved resources and depth counter
 	te.xobjectDepth--
-	te.ctm = savedCTM
+	te.restoreGraphicsState(savedGraphicsState)
 	te.graphicsStateStack = savedGraphicsStateStack
+	if xobjResources != nil {
+		te.fontDecoders = savedFontDecoders
+		te.fontMetrics = savedFontMetrics
+	}
 	if len(te.resourceStack) > 0 {
 		te.pageResources = te.resourceStack[len(te.resourceStack)-1]
 		te.resourceStack = te.resourceStack[:len(te.resourceStack)-1]
@@ -1012,9 +1052,9 @@ func (te *TextExtractor) getPageResources(page *parser.Dictionary) *parser.Dicti
 // If the font cannot be loaded or has no ToUnicode CMap, we create
 // a default decoder that will use fallback encoding (Latin-1).
 func (te *TextExtractor) loadFontDecoder(fontName string) {
-	// fontMetrics shares the same per-page cache lifecycle as fontDecoders.
-	// If the decoder already exists, it was loaded in this extraction pass
-	// and the associated metrics are still valid.
+	// fontMetrics shares the same resource-scope lifecycle as fontDecoders.
+	// ExtractFromPage resets the page caches, and processFormXObject swaps both
+	// caches when a Form supplies its own Resources dictionary.
 	if _, exists := te.fontDecoders[fontName]; exists {
 		return
 	}

--- a/internal/extractor/text_extractor.go
+++ b/internal/extractor/text_extractor.go
@@ -1012,7 +1012,9 @@ func (te *TextExtractor) getPageResources(page *parser.Dictionary) *parser.Dicti
 // If the font cannot be loaded or has no ToUnicode CMap, we create
 // a default decoder that will use fallback encoding (Latin-1).
 func (te *TextExtractor) loadFontDecoder(fontName string) {
-	// Check if already loaded
+	// fontMetrics shares the same per-page cache lifecycle as fontDecoders.
+	// If the decoder already exists, it was loaded in this extraction pass
+	// and the associated metrics are still valid.
 	if _, exists := te.fontDecoders[fontName]; exists {
 		return
 	}

--- a/internal/tabledetect/column_boundary_compaction_test.go
+++ b/internal/tabledetect/column_boundary_compaction_test.go
@@ -98,6 +98,38 @@ func TestDetectBoundariesRightAlignedTables(t *testing.T) {
 	}
 }
 
+func TestDetectBoundariesIgnoresUnrelatedFarRightPageText(t *testing.T) {
+	tests := []struct {
+		name     string
+		outliers []*extractor.TextElement
+	}{
+		{
+			name: "standalone page number",
+			outliers: []*extractor.TextElement{
+				extractor.NewTextElement("Page 1", 700, 20, 30, 10, "F1", 10),
+			},
+		},
+		{
+			name: "header metadata row",
+			outliers: []*extractor.TextElement{
+				extractor.NewTextElement("Annual report", 20, 160, 80, 10, "F1", 10),
+				extractor.NewTextElement("Page 1", 700, 160, 30, 10, "F1", 10),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			elements := append(rightAlignedTableElements(3, false), test.outliers...)
+			detector := NewColumnBoundaryDetector()
+			boundaries := detector.DetectBoundaries(elements)
+
+			assert.Len(t, boundaries, 5)
+			assert.InDelta(t, 400, boundaries[len(boundaries)-1], 1e-6)
+		})
+	}
+}
+
 func rightAlignedTableElements(numericCols int, missingValue bool) []*extractor.TextElement {
 	elements := []*extractor.TextElement{
 		extractor.NewTextElement("Line Item", 20, 120, 60, 10, "F1", 10),

--- a/internal/tabledetect/column_boundary_compaction_test.go
+++ b/internal/tabledetect/column_boundary_compaction_test.go
@@ -149,20 +149,33 @@ func TestDetectBoundariesKeepsSparseTerminalValueOnAdjacentRow(t *testing.T) {
 }
 
 func TestDetectBoundariesKeepsSparseTerminalValueAfterSectionGap(t *testing.T) {
-	elements := []*extractor.TextElement{
-		extractor.NewTextElement("Line Item", 20, 120, 60, 10, "F1", 10),
-		extractor.NewTextElement("2023", 176, 120, 24, 10, "F1", 10),
-		extractor.NewTextElement("Revenue", 20, 100, 50, 10, "F1", 10),
-		extractor.NewTextElement("1200", 176, 100, 24, 10, "F1", 10),
-		extractor.NewTextElement("Cost", 20, 80, 30, 10, "F1", 10),
-		extractor.NewTextElement("(400)", 170, 80, 30, 10, "F1", 10),
-		extractor.NewTextElement("Other", 20, 40, 30, 10, "F1", 10),
-		extractor.NewTextElement("900", 382, 40, 18, 10, "F1", 10),
+	tests := []struct {
+		name  string
+		value string
+		width float64
+	}{
+		{name: "integer", value: "900", width: 18},
+		{name: "Unicode minus", value: "−570", width: 24},
+		{name: "European currency", value: "€ 1.450,00", width: 54},
 	}
 
-	boundaries := NewColumnBoundaryDetector().DetectBoundaries(elements)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			elements := []*extractor.TextElement{
+				extractor.NewTextElement("Line Item", 20, 120, 60, 10, "F1", 10),
+				extractor.NewTextElement("2023", 176, 120, 24, 10, "F1", 10),
+				extractor.NewTextElement("Revenue", 20, 100, 50, 10, "F1", 10),
+				extractor.NewTextElement("1200", 176, 100, 24, 10, "F1", 10),
+				extractor.NewTextElement("Cost", 20, 80, 30, 10, "F1", 10),
+				extractor.NewTextElement("(400)", 170, 80, 30, 10, "F1", 10),
+				extractor.NewTextElement("Other", 20, 40, 30, 10, "F1", 10),
+				extractor.NewTextElement(test.value, 400-test.width, 40, test.width, 10, "F1", 10),
+			}
 
-	assert.Equal(t, []float64{20, 170, 382, 400}, boundaries)
+			boundaries := NewColumnBoundaryDetector().DetectBoundaries(elements)
+			assert.Equal(t, []float64{20, 170, 400 - test.width, 400}, boundaries)
+		})
+	}
 }
 
 func TestDetectBoundariesRejectsNearbyPageNumberRows(t *testing.T) {

--- a/internal/tabledetect/column_boundary_compaction_test.go
+++ b/internal/tabledetect/column_boundary_compaction_test.go
@@ -1,0 +1,71 @@
+package tabledetect
+
+import (
+	"testing"
+
+	"github.com/coregx/gxpdf/internal/extractor"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompleteAndCompactBoundaries(t *testing.T) {
+	tests := []struct {
+		name       string
+		boundaries []float64
+		elements   []*extractor.TextElement
+		want       []float64
+	}{
+		{
+			name:       "restores terminal edge and removes whitespace interval",
+			boundaries: []float64{60, 99, 185, 235},
+			elements: tableElements(
+				[]float64{60, 185, 235},
+				[][]float64{{39, 15, 15}, {27, 12, 12}, {21, 12, 12}},
+			),
+			want: []float64{60, 185, 235, 250},
+		},
+		{
+			name:       "keeps a column represented in only one row",
+			boundaries: []float64{20, 80, 150, 210},
+			elements: []*extractor.TextElement{
+				extractor.NewTextElement("label", 20, 100, 50, 10, "F1", 10),
+				extractor.NewTextElement("first", 150, 100, 20, 10, "F1", 10),
+				extractor.NewTextElement("second", 210, 80, 20, 10, "F1", 10),
+			},
+			want: []float64{20, 150, 210, 230},
+		},
+		{
+			name:       "preserves already compact boundaries",
+			boundaries: []float64{10, 100, 200},
+			elements: []*extractor.TextElement{
+				extractor.NewTextElement("left", 10, 50, 20, 10, "F1", 10),
+				extractor.NewTextElement("right", 120, 50, 20, 10, "F1", 10),
+			},
+			want: []float64{10, 100, 200},
+		},
+		{
+			name:       "empty input",
+			boundaries: nil,
+			elements:   nil,
+			want:       nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			detector := NewColumnBoundaryDetector()
+			assert.Equal(t, test.want, detector.completeAndCompactBoundaries(test.boundaries, test.elements))
+		})
+	}
+}
+
+func tableElements(starts []float64, rowWidths [][]float64) []*extractor.TextElement {
+	var elements []*extractor.TextElement
+	for row, widths := range rowWidths {
+		for column, width := range widths {
+			elements = append(elements, extractor.NewTextElement(
+				"cell", starts[column], 100-float64(row)*15, width, 10, "F1", 10,
+			))
+		}
+	}
+	return elements
+}

--- a/internal/tabledetect/column_boundary_compaction_test.go
+++ b/internal/tabledetect/column_boundary_compaction_test.go
@@ -1,6 +1,7 @@
 package tabledetect
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coregx/gxpdf/internal/extractor"
@@ -43,6 +44,19 @@ func TestCompleteAndCompactBoundaries(t *testing.T) {
 			want: []float64{10, 100, 200},
 		},
 		{
+			name:       "snaps clustered terminal edge without adding a phantom column",
+			boundaries: []float64{20, 50, 199.5, 299.5},
+			elements: []*extractor.TextElement{
+				extractor.NewTextElement("Revenue", 20, 100, 50, 10, "F1", 10),
+				extractor.NewTextElement("9", 199, 100, 1, 10, "F1", 10),
+				extractor.NewTextElement("1000", 296, 100, 4, 10, "F1", 10),
+				extractor.NewTextElement("Cost", 20, 80, 30, 10, "F1", 10),
+				extractor.NewTextElement("(400)", 195, 80, 5, 10, "F1", 10),
+				extractor.NewTextElement("(7)", 297, 80, 3, 10, "F1", 10),
+			},
+			want: []float64{20, 50, 199.5, 300},
+		},
+		{
 			name:       "empty input",
 			boundaries: nil,
 			elements:   nil,
@@ -56,6 +70,54 @@ func TestCompleteAndCompactBoundaries(t *testing.T) {
 			assert.Equal(t, test.want, detector.completeAndCompactBoundaries(test.boundaries, test.elements))
 		})
 	}
+}
+
+func TestDetectBoundariesRightAlignedTables(t *testing.T) {
+	tests := []struct {
+		name         string
+		numericCols  int
+		missingValue bool
+	}{
+		{name: "two value columns", numericCols: 2},
+		{name: "three value columns", numericCols: 3, missingValue: true},
+		{name: "four value columns", numericCols: 4},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			elements := rightAlignedTableElements(test.numericCols, test.missingValue)
+			detector := NewColumnBoundaryDetector()
+			boundaries := detector.DetectBoundaries(elements)
+			assert.Len(t, boundaries, test.numericCols+2)
+			_, maxX := detector.findExtent(elements)
+			assert.InDelta(t, maxX, boundaries[len(boundaries)-1], 1e-6)
+			for index := 1; index < len(boundaries); index++ {
+				assert.Greater(t, boundaries[index]-boundaries[index-1], detector.minGapWidth/2)
+			}
+		})
+	}
+}
+
+func rightAlignedTableElements(numericCols int, missingValue bool) []*extractor.TextElement {
+	elements := []*extractor.TextElement{
+		extractor.NewTextElement("Line Item", 20, 120, 60, 10, "F1", 10),
+		extractor.NewTextElement("Revenue", 20, 100, 50, 10, "F1", 10),
+		extractor.NewTextElement("Cost", 20, 80, 30, 10, "F1", 10),
+	}
+	for column := 0; column < numericCols; column++ {
+		right := 200.0 + float64(column)*100
+		values := []string{fmt.Sprintf("20%02d", column), "9", "(400)"}
+		widths := []float64{24, 6, 30}
+		for row := range values {
+			if missingValue && column == 1 && row == 1 {
+				continue
+			}
+			elements = append(elements, extractor.NewTextElement(
+				values[row], right-widths[row], 120-float64(row)*20, widths[row], 10, "F1", 10,
+			))
+		}
+	}
+	return elements
 }
 
 func tableElements(starts []float64, rowWidths [][]float64) []*extractor.TextElement {

--- a/internal/tabledetect/column_boundary_compaction_test.go
+++ b/internal/tabledetect/column_boundary_compaction_test.go
@@ -130,6 +130,24 @@ func TestDetectBoundariesIgnoresUnrelatedFarRightPageText(t *testing.T) {
 	}
 }
 
+func TestDetectBoundariesKeepsSparseTerminalValueOnAdjacentRow(t *testing.T) {
+	elements := []*extractor.TextElement{
+		extractor.NewTextElement("Line Item", 20, 120, 60, 10, "F1", 10),
+		extractor.NewTextElement("2023", 176, 120, 24, 10, "F1", 10),
+		extractor.NewTextElement("Revenue", 20, 100, 50, 10, "F1", 10),
+		extractor.NewTextElement("1200", 176, 100, 24, 10, "F1", 10),
+		extractor.NewTextElement("Cost", 20, 80, 30, 10, "F1", 10),
+		extractor.NewTextElement("(400)", 170, 80, 30, 10, "F1", 10),
+		extractor.NewTextElement("Other", 20, 60, 30, 10, "F1", 10),
+		extractor.NewTextElement("1450", 376, 60, 24, 10, "F1", 10),
+	}
+
+	detector := NewColumnBoundaryDetector()
+	boundaries := detector.DetectBoundaries(elements)
+
+	assert.Equal(t, []float64{20, 170, 376, 400}, boundaries)
+}
+
 func rightAlignedTableElements(numericCols int, missingValue bool) []*extractor.TextElement {
 	elements := []*extractor.TextElement{
 		extractor.NewTextElement("Line Item", 20, 120, 60, 10, "F1", 10),

--- a/internal/tabledetect/column_boundary_compaction_test.go
+++ b/internal/tabledetect/column_boundary_compaction_test.go
@@ -148,6 +148,52 @@ func TestDetectBoundariesKeepsSparseTerminalValueOnAdjacentRow(t *testing.T) {
 	assert.Equal(t, []float64{20, 170, 376, 400}, boundaries)
 }
 
+func TestDetectBoundariesKeepsSparseTerminalValueAfterSectionGap(t *testing.T) {
+	elements := []*extractor.TextElement{
+		extractor.NewTextElement("Line Item", 20, 120, 60, 10, "F1", 10),
+		extractor.NewTextElement("2023", 176, 120, 24, 10, "F1", 10),
+		extractor.NewTextElement("Revenue", 20, 100, 50, 10, "F1", 10),
+		extractor.NewTextElement("1200", 176, 100, 24, 10, "F1", 10),
+		extractor.NewTextElement("Cost", 20, 80, 30, 10, "F1", 10),
+		extractor.NewTextElement("(400)", 170, 80, 30, 10, "F1", 10),
+		extractor.NewTextElement("Other", 20, 40, 30, 10, "F1", 10),
+		extractor.NewTextElement("900", 382, 40, 18, 10, "F1", 10),
+	}
+
+	boundaries := NewColumnBoundaryDetector().DetectBoundaries(elements)
+
+	assert.Equal(t, []float64{20, 170, 382, 400}, boundaries)
+}
+
+func TestDetectBoundariesRejectsNearbyPageNumberRows(t *testing.T) {
+	tests := []struct {
+		name string
+		row  []*extractor.TextElement
+	}{
+		{
+			name: "label and far-right page number",
+			row: []*extractor.TextElement{
+				extractor.NewTextElement("Note", 20, 60, 25, 10, "F1", 10),
+				extractor.NewTextElement("Page 1", 700, 60, 30, 10, "F1", 10),
+			},
+		},
+		{
+			name: "centered page number",
+			row: []*extractor.TextElement{
+				extractor.NewTextElement("Page 1 of 12", 180, 60, 60, 10, "F1", 10),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			elements := append(rightAlignedTableElements(2, false), test.row...)
+			boundaries := NewColumnBoundaryDetector().DetectBoundaries(elements)
+			assert.Equal(t, []float64{20, 170, 270, 300}, boundaries)
+		})
+	}
+}
+
 func rightAlignedTableElements(numericCols int, missingValue bool) []*extractor.TextElement {
 	elements := []*extractor.TextElement{
 		extractor.NewTextElement("Line Item", 20, 120, 60, 10, "F1", 10),

--- a/internal/tabledetect/column_boundary_detector.go
+++ b/internal/tabledetect/column_boundary_detector.go
@@ -309,7 +309,8 @@ func rowContainsNumericValue(row []*extractor.TextElement) bool {
 			switch {
 			case unicode.IsDigit(value):
 				hasDigit = true
-			case unicode.IsSpace(value), strings.ContainsRune("+-(),.'’$€£¥₹%", value):
+			case unicode.IsSpace(value), unicode.Is(unicode.Dash, value),
+				strings.ContainsRune("+(),.'’$€£¥₹%", value):
 			default:
 				valid = false
 			}

--- a/internal/tabledetect/column_boundary_detector.go
+++ b/internal/tabledetect/column_boundary_detector.go
@@ -193,24 +193,82 @@ func (cbd *ColumnBoundaryDetector) elementsInSupportedRows(
 		start = end
 	}
 
-	result := make([]*extractor.TextElement, 0, len(elements))
-	for _, row := range cbd.groupElementsByRow(elements) {
+	type supportedRow struct {
+		elements []*extractor.TextElement
+		y        float64
+		aligned  int
+		core     bool
+	}
+	groupedRows := cbd.groupElementsByRow(elements)
+	rows := make([]supportedRow, 0, len(groupedRows))
+	coreY := make([]float64, 0, len(groupedRows))
+	for _, row := range groupedRows {
 		aligned := 0
+		y := 0.0
 		for _, element := range row {
+			y += element.Y
 			if supportedElements[element] {
 				aligned++
 			}
 		}
-		if aligned < 2 {
-			continue
+		y /= float64(len(row))
+		isCore := aligned >= 2
+		rows = append(rows, supportedRow{elements: row, y: y, aligned: aligned, core: isCore})
+		if isCore {
+			coreY = append(coreY, y)
 		}
-		result = append(result, row...)
+	}
+
+	// A sparse row may contain a value only in a terminal column. It will then
+	// share just its label edge with the established table and must not be
+	// mistaken for unrelated page text. Admit one-edge rows when they continue
+	// the table's vertical rhythm; distant headers and footers remain excluded.
+	adjacency := supportedRowAdjacency(coreY)
+	result := make([]*extractor.TextElement, 0, len(elements))
+	for _, row := range rows {
+		if row.core || (row.aligned == 1 && rowIsAdjacentToCore(row.y, coreY, adjacency)) {
+			result = append(result, row.elements...)
+		}
 	}
 
 	if len(result) == 0 || len(result) == len(elements) {
 		return elements, false
 	}
 	return result, true
+}
+
+func supportedRowAdjacency(coreY []float64) float64 {
+	if len(coreY) < 2 {
+		return 0
+	}
+	sorted := append([]float64(nil), coreY...)
+	sort.Float64s(sorted)
+	gaps := make([]float64, 0, len(sorted)-1)
+	for index := 1; index < len(sorted); index++ {
+		if gap := sorted[index] - sorted[index-1]; gap > 0 {
+			gaps = append(gaps, gap)
+		}
+	}
+	if len(gaps) == 0 {
+		return 0
+	}
+	sort.Float64s(gaps)
+	// Prefer the lower median when only a few rows establish the rhythm. One
+	// large section gap must not make a distant page header look adjacent.
+	medianGap := gaps[(len(gaps)-1)/2]
+	return medianGap * 1.5
+}
+
+func rowIsAdjacentToCore(y float64, coreY []float64, adjacency float64) bool {
+	if adjacency <= 0 {
+		return false
+	}
+	for _, candidate := range coreY {
+		if math.Abs(y-candidate) <= adjacency {
+			return true
+		}
+	}
+	return false
 }
 
 func boundariesWithinExtent(boundaries []float64, minX, maxX, tolerance float64) []float64 {

--- a/internal/tabledetect/column_boundary_detector.go
+++ b/internal/tabledetect/column_boundary_detector.go
@@ -108,12 +108,25 @@ func (cbd *ColumnBoundaryDetector) completeAndCompactBoundaries(
 	minX, maxX := cbd.findExtent(elements)
 	completed := append([]float64(nil), boundaries...)
 	sort.Float64s(completed)
-	const coordinateEpsilon = 1e-6
-	if completed[0]-minX > coordinateEpsilon {
-		completed = append([]float64{minX}, completed...)
+	// Edge clusters are medians, so an outer cluster can legitimately land a
+	// fraction of a point inside the true extent. Treat positions within the
+	// clustering radius as the same edge and snap them to the extent. Appending
+	// both would create a narrow phantom terminal column.
+	edgeTolerance := cbd.minGapWidth / 2
+	if completed[0] > minX {
+		if completed[0]-minX <= edgeTolerance {
+			completed[0] = minX
+		} else {
+			completed = append([]float64{minX}, completed...)
+		}
 	}
-	if maxX-completed[len(completed)-1] > coordinateEpsilon {
-		completed = append(completed, maxX)
+	last := len(completed) - 1
+	if completed[last] < maxX {
+		if maxX-completed[last] <= edgeTolerance {
+			completed[last] = maxX
+		} else {
+			completed = append(completed, maxX)
+		}
 	}
 
 	for interval := 0; interval < len(completed)-1; {
@@ -135,9 +148,15 @@ func (cbd *ColumnBoundaryDetector) completeAndCompactBoundaries(
 }
 
 func intervalContainsTextCenter(left, right float64, elements []*extractor.TextElement, includeRight bool) bool {
+	const coordinateEpsilon = 1e-6
 	for _, element := range elements {
 		center := element.CenterX()
-		if center >= left && (center < right || includeRight && center <= right) {
+		// A center exactly on a candidate edge is evidence that the edge cuts
+		// through text, not that the interval to its right is populated. Keep
+		// the center strictly inside an interval so variable-width labels do not
+		// turn their right edges into phantom columns.
+		if center > left+coordinateEpsilon &&
+			(center < right-coordinateEpsilon || includeRight && center <= right+coordinateEpsilon) {
 			return true
 		}
 	}

--- a/internal/tabledetect/column_boundary_detector.go
+++ b/internal/tabledetect/column_boundary_detector.go
@@ -105,7 +105,14 @@ func (cbd *ColumnBoundaryDetector) completeAndCompactBoundaries(
 		return boundaries
 	}
 
-	minX, maxX := cbd.findExtent(elements)
+	// Complete the outer edges only from text that participates in repeated row
+	// structure. A page number or caption can sit well outside a table, and using
+	// the page-wide extent here would turn that unrelated text into a phantom
+	// terminal column. Once a row has two cells aligned to repeated page edges,
+	// keep the whole row so a sparse column represented in only one row can still
+	// contribute its outer edge.
+	extentElements, excludedOutliers := cbd.elementsInSupportedRows(elements)
+	minX, maxX := cbd.findExtent(extentElements)
 	completed := append([]float64(nil), boundaries...)
 	sort.Float64s(completed)
 	// Edge clusters are medians, so an outer cluster can legitimately land a
@@ -113,6 +120,12 @@ func (cbd *ColumnBoundaryDetector) completeAndCompactBoundaries(
 	// clustering radius as the same edge and snap them to the extent. Appending
 	// both would create a narrow phantom terminal column.
 	edgeTolerance := cbd.minGapWidth / 2
+	if excludedOutliers {
+		completed = boundariesWithinExtent(completed, minX, maxX, edgeTolerance)
+		if len(completed) == 0 {
+			return boundaries
+		}
+	}
 	if completed[0] > minX {
 		if completed[0]-minX <= edgeTolerance {
 			completed[0] = minX
@@ -130,7 +143,7 @@ func (cbd *ColumnBoundaryDetector) completeAndCompactBoundaries(
 	}
 
 	for interval := 0; interval < len(completed)-1; {
-		if intervalContainsTextCenter(completed[interval], completed[interval+1], elements, interval == len(completed)-2) {
+		if intervalContainsTextCenter(completed[interval], completed[interval+1], extentElements, interval == len(completed)-2) {
 			interval++
 			continue
 		}
@@ -145,6 +158,69 @@ func (cbd *ColumnBoundaryDetector) completeAndCompactBoundaries(
 	}
 
 	return completed
+}
+
+func (cbd *ColumnBoundaryDetector) elementsInSupportedRows(
+	elements []*extractor.TextElement,
+) ([]*extractor.TextElement, bool) {
+	tolerance := cbd.minGapWidth / 2
+	type positionedEdge struct {
+		x       float64
+		element *extractor.TextElement
+	}
+	edges := make([]positionedEdge, 0, len(elements)*2)
+	for _, element := range elements {
+		edges = append(edges,
+			positionedEdge{x: element.X, element: element},
+			positionedEdge{x: element.Right(), element: element},
+		)
+	}
+	sort.Slice(edges, func(i, j int) bool { return edges[i].x < edges[j].x })
+
+	supportedElements := make(map[*extractor.TextElement]bool, len(elements))
+	for start := 0; start < len(edges); {
+		end := start + 1
+		owners := map[*extractor.TextElement]struct{}{edges[start].element: {}}
+		for end < len(edges) && edges[end].x-edges[end-1].x <= tolerance {
+			owners[edges[end].element] = struct{}{}
+			end++
+		}
+		if len(owners) >= 2 {
+			for element := range owners {
+				supportedElements[element] = true
+			}
+		}
+		start = end
+	}
+
+	result := make([]*extractor.TextElement, 0, len(elements))
+	for _, row := range cbd.groupElementsByRow(elements) {
+		aligned := 0
+		for _, element := range row {
+			if supportedElements[element] {
+				aligned++
+			}
+		}
+		if aligned < 2 {
+			continue
+		}
+		result = append(result, row...)
+	}
+
+	if len(result) == 0 || len(result) == len(elements) {
+		return elements, false
+	}
+	return result, true
+}
+
+func boundariesWithinExtent(boundaries []float64, minX, maxX, tolerance float64) []float64 {
+	result := make([]float64, 0, len(boundaries))
+	for _, boundary := range boundaries {
+		if boundary >= minX-tolerance && boundary <= maxX+tolerance {
+			result = append(result, boundary)
+		}
+	}
+	return result
 }
 
 func intervalContainsTextCenter(left, right float64, elements []*extractor.TextElement, includeRight bool) bool {

--- a/internal/tabledetect/column_boundary_detector.go
+++ b/internal/tabledetect/column_boundary_detector.go
@@ -83,10 +83,65 @@ func (cbd *ColumnBoundaryDetector) DetectBoundaries(elements []*extractor.TextEl
 
 	if len(boundaries) == 0 {
 		// Fallback to header-based
-		return cbd.detectBoundariesHeaderBased(elements)
+		boundaries = cbd.detectBoundariesHeaderBased(elements)
 	}
 
-	return boundaries
+	return cbd.completeAndCompactBoundaries(boundaries, elements)
+}
+
+// completeAndCompactBoundaries turns clustered text edges into cell boundaries.
+//
+// Edge clustering can select the right edge of one column and the left edge of
+// the next as two separate boundaries. The interval between them is whitespace,
+// not a logical column. It can also omit the final content edge when that edge
+// is closer than minColumnWidth to the last selected cluster. Complete the
+// outer extent first, then remove intervals that contain no text center by
+// folding their whitespace into the column on the left.
+func (cbd *ColumnBoundaryDetector) completeAndCompactBoundaries(
+	boundaries []float64,
+	elements []*extractor.TextElement,
+) []float64 {
+	if len(boundaries) == 0 || len(elements) == 0 {
+		return boundaries
+	}
+
+	minX, maxX := cbd.findExtent(elements)
+	completed := append([]float64(nil), boundaries...)
+	sort.Float64s(completed)
+	const coordinateEpsilon = 1e-6
+	if completed[0]-minX > coordinateEpsilon {
+		completed = append([]float64{minX}, completed...)
+	}
+	if maxX-completed[len(completed)-1] > coordinateEpsilon {
+		completed = append(completed, maxX)
+	}
+
+	for interval := 0; interval < len(completed)-1; {
+		if intervalContainsTextCenter(completed[interval], completed[interval+1], elements, interval == len(completed)-2) {
+			interval++
+			continue
+		}
+
+		if interval == 0 {
+			completed = append(completed[:1], completed[2:]...)
+			continue
+		}
+
+		completed = append(completed[:interval], completed[interval+1:]...)
+		interval--
+	}
+
+	return completed
+}
+
+func intervalContainsTextCenter(left, right float64, elements []*extractor.TextElement, includeRight bool) bool {
+	for _, element := range elements {
+		center := element.CenterX()
+		if center >= left && (center < right || includeRight && center <= right) {
+			return true
+		}
+	}
+	return false
 }
 
 // DetectBoundariesWithRulingLines detects column boundaries using HYBRID approach.
@@ -1204,158 +1259,13 @@ func (cbd *ColumnBoundaryDetector) median(values []float64) float64 {
 //	Phase 2: Use boundary count as column count
 func (cbd *ColumnBoundaryDetector) DetectColumnCount(elements []*extractor.TextElement) int {
 	boundaries := cbd.DetectBoundaries(elements)
-
-	// Column count = number of boundary pairs
-	// For N boundaries, we have (N-1)/2 columns (assuming left+right boundaries)
-	// But simpler: count gaps between boundaries
 	if len(boundaries) < 2 {
 		return 1 // At least 1 column
 	}
 
-	// Each gap represents a column
-	// For boundaries [x1, x2, x3, x4, x5, x6, x7], we have gaps:
-	// [x1-x2], [x2-x3], [x3-x4], [x4-x5], [x5-x6], [x6-x7]
-	// But adjacent pairs are column edges, so real columns = len(boundaries) / 2
-
-	// Actually, a better approach:
-	// Boundaries represent left edges of columns
-	// So number of columns ≈ number of boundaries
-	// But we need to be smarter...
-
-	// Let's use a different approach: count significant gaps
-	gaps := []float64{}
-	for i := 1; i < len(boundaries); i++ {
-		gap := boundaries[i] - boundaries[i-1]
-		if gap >= cbd.minColumnWidth {
-			gaps = append(gaps, gap)
-		}
-	}
-
-	// Cluster gaps into "column widths" and "inter-column spaces"
-	// For now, simple heuristic: count boundaries as column starts
-	return cbd.countColumnsFromBoundaries(boundaries)
-}
-
-// countColumnsFromBoundaries estimates column count from boundaries.
-//
-// Strategy:
-// - For N boundaries, gaps alternate between "column widths" and "inter-column spaces"
-// - Use k-means-like clustering to find 2 groups of gaps: small and large
-// - Small gaps = column widths (left edge → right edge)
-// - Large gaps = inter-column spaces
-// - Count columns based on alternating pattern
-func (cbd *ColumnBoundaryDetector) countColumnsFromBoundaries(boundaries []float64) int {
-	if len(boundaries) == 0 {
-		return 1
-	}
-	if len(boundaries) == 1 {
-		return 1
-	}
-	if len(boundaries) == 2 {
-		// 2 boundaries = 1 column (left and right edges)
-		return 1
-	}
-
-	// Calculate gaps between consecutive boundaries
-	gaps := make([]float64, 0, len(boundaries)-1)
-	for i := 1; i < len(boundaries); i++ {
-		gaps = append(gaps, boundaries[i]-boundaries[i-1])
-	}
-
-	if len(gaps) == 0 {
-		return 1
-	}
-
-	// Simple heuristic: if all gaps are similar, assume alternating pattern
-	// For [50, 100, 150, 200, 250, 300] → gaps [50, 50, 50, 50, 50]
-	// This represents 3 columns (every 2 boundaries = 1 column)
-
-	// Check if gaps are uniform (all similar)
-	if cbd.areGapsUniform(gaps) {
-		// Uniform gaps - boundaries alternate: left, right, left, right, ...
-		// Number of columns = ceil(boundaries / 2)
-		return (len(boundaries) + 1) / 2
-	}
-
-	// Non-uniform gaps - cluster into small (column width) and large (inter-column)
-	threshold := cbd.findGapThreshold(gaps)
-
-	// Count large gaps (inter-column spaces)
-	interColumnGaps := 0
-	for _, gap := range gaps {
-		if gap >= threshold {
-			interColumnGaps++
-		}
-	}
-
-	// Number of columns = inter-column gaps + 1
-	return max(1, interColumnGaps+1)
-}
-
-// areGapsUniform checks if all gaps are similar (within 20% of median).
-func (cbd *ColumnBoundaryDetector) areGapsUniform(gaps []float64) bool {
-	if len(gaps) == 0 {
-		return true
-	}
-
-	median := cbd.median(gaps)
-	tolerance := median * 0.2 // 20% tolerance
-
-	for _, gap := range gaps {
-		if abs(gap-median) > tolerance {
-			return false
-		}
-	}
-
-	return true
-}
-
-// findGapThreshold finds threshold to separate small gaps from large gaps.
-//
-// Uses mean of all gaps as threshold (simple k-means with k=2).
-func (cbd *ColumnBoundaryDetector) findGapThreshold(gaps []float64) float64 {
-	if len(gaps) == 0 {
-		return cbd.minColumnWidth
-	}
-
-	// Use mean as initial threshold
-	mean := cbd.mean(gaps)
-
-	// Refine using k-means iteration (just 1 iteration for simplicity)
-	smallGaps := []float64{}
-	largeGaps := []float64{}
-
-	for _, gap := range gaps {
-		if gap < mean {
-			smallGaps = append(smallGaps, gap)
-		} else {
-			largeGaps = append(largeGaps, gap)
-		}
-	}
-
-	// Calculate centroids
-	var smallCentroid, largeCentroid float64
-	if len(smallGaps) > 0 {
-		smallCentroid = cbd.mean(smallGaps)
-	}
-	if len(largeGaps) > 0 {
-		largeCentroid = cbd.mean(largeGaps)
-	}
-
-	// Threshold = midpoint between centroids
-	if len(smallGaps) > 0 && len(largeGaps) > 0 {
-		return (smallCentroid + largeCentroid) / 2.0
-	}
-
-	// Fallback to mean
-	return mean
-}
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
+	// DetectBoundaries now returns compact logical cell edges, so every
+	// adjacent boundary pair describes exactly one column.
+	return len(boundaries) - 1
 }
 
 // AssignToColumns assigns text elements to columns based on detected boundaries.

--- a/internal/tabledetect/column_boundary_detector.go
+++ b/internal/tabledetect/column_boundary_detector.go
@@ -4,8 +4,15 @@ package tabledetect
 import (
 	"math"
 	"sort"
+	"strings"
+	"unicode"
 
 	"github.com/coregx/gxpdf/internal/extractor"
+)
+
+const (
+	standardRowAdjacencyFactor    = 1.5
+	sparseValueRowAdjacencyFactor = 2.5
 )
 
 // ColumnBoundaryDetector detects column boundaries using adaptive statistical analysis.
@@ -212,7 +219,8 @@ func (cbd *ColumnBoundaryDetector) elementsInSupportedRows(
 			}
 		}
 		y /= float64(len(row))
-		isCore := aligned >= 2
+		pageMetadata := rowContainsPageNumber(row) && !rowContainsNumericValue(row)
+		isCore := aligned >= 2 && !pageMetadata
 		rows = append(rows, supportedRow{elements: row, y: y, aligned: aligned, core: isCore})
 		if isCore {
 			coreY = append(coreY, y)
@@ -224,9 +232,17 @@ func (cbd *ColumnBoundaryDetector) elementsInSupportedRows(
 	// mistaken for unrelated page text. Admit one-edge rows when they continue
 	// the table's vertical rhythm; distant headers and footers remain excluded.
 	adjacency := supportedRowAdjacency(coreY)
+	sparseValueAdjacency := supportedSparseValueRowAdjacency(coreY)
 	result := make([]*extractor.TextElement, 0, len(elements))
 	for _, row := range rows {
-		if row.core || (row.aligned == 1 && rowIsAdjacentToCore(row.y, coreY, adjacency)) {
+		if rowContainsPageNumber(row.elements) && !rowContainsNumericValue(row.elements) {
+			continue
+		}
+		rowAdjacency := adjacency
+		if rowContainsNumericValue(row.elements) {
+			rowAdjacency = sparseValueAdjacency
+		}
+		if row.core || (row.aligned == 1 && rowIsAdjacentToCore(row.y, coreY, rowAdjacency)) {
 			result = append(result, row.elements...)
 		}
 	}
@@ -238,6 +254,14 @@ func (cbd *ColumnBoundaryDetector) elementsInSupportedRows(
 }
 
 func supportedRowAdjacency(coreY []float64) float64 {
+	return supportedRowAdjacencyWithFactor(coreY, standardRowAdjacencyFactor)
+}
+
+func supportedSparseValueRowAdjacency(coreY []float64) float64 {
+	return supportedRowAdjacencyWithFactor(coreY, sparseValueRowAdjacencyFactor)
+}
+
+func supportedRowAdjacencyWithFactor(coreY []float64, factor float64) float64 {
 	if len(coreY) < 2 {
 		return 0
 	}
@@ -256,7 +280,57 @@ func supportedRowAdjacency(coreY []float64) float64 {
 	// Prefer the lower median when only a few rows establish the rhythm. One
 	// large section gap must not make a distant page header look adjacent.
 	medianGap := gaps[(len(gaps)-1)/2]
-	return medianGap * 1.5
+	return medianGap * factor
+}
+
+func rowContainsPageNumber(row []*extractor.TextElement) bool {
+	for _, element := range row {
+		fields := strings.Fields(strings.ToLower(strings.TrimSpace(element.Text)))
+		if len(fields) == 2 && fields[0] == "page" && isDecimalDigits(fields[1]) {
+			return true
+		}
+		if len(fields) == 4 && fields[0] == "page" && fields[2] == "of" &&
+			isDecimalDigits(fields[1]) && isDecimalDigits(fields[3]) {
+			return true
+		}
+	}
+	return false
+}
+
+func rowContainsNumericValue(row []*extractor.TextElement) bool {
+	for _, element := range row {
+		text := strings.TrimSpace(element.Text)
+		if text == "" {
+			continue
+		}
+		hasDigit := false
+		valid := true
+		for _, value := range text {
+			switch {
+			case unicode.IsDigit(value):
+				hasDigit = true
+			case unicode.IsSpace(value), strings.ContainsRune("+-(),.'’$€£¥₹%", value):
+			default:
+				valid = false
+			}
+		}
+		if valid && hasDigit {
+			return true
+		}
+	}
+	return false
+}
+
+func isDecimalDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, digit := range value {
+		if digit < '0' || digit > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func rowIsAdjacentToCore(y float64, coreY []float64, adjacency float64) bool {

--- a/internal/tabledetect/table_detector.go
+++ b/internal/tabledetect/table_detector.go
@@ -298,7 +298,8 @@ func (td *DefaultTableDetector) detectStream(textElements []*extractor.TextEleme
 
 	// Detect columns and rows
 	columns := td.whitespaceAnalyzer.DetectColumns(textElements)
-	rows := td.whitespaceAnalyzer.DetectRows(textElements)
+	tableElements := elementsWithinColumnExtent(textElements, columns)
+	rows := td.whitespaceAnalyzer.DetectRows(tableElements)
 
 	// Need at least 2 rows and 2 columns for a table
 	if len(columns) < 2 || len(rows) < 2 {
@@ -307,7 +308,7 @@ func (td *DefaultTableDetector) detectStream(textElements []*extractor.TextEleme
 	}
 
 	// Calculate bounding rectangle
-	bounds := td.calculateBoundsFromText(textElements)
+	bounds := td.calculateBoundsFromText(tableElements)
 
 	// Create table region
 	region := NewTableRegion(bounds, MethodStream)
@@ -316,6 +317,26 @@ func (td *DefaultTableDetector) detectStream(textElements []*extractor.TextEleme
 	region.HasRulingLines = false
 
 	return []*TableRegion{region}, nil
+}
+
+func elementsWithinColumnExtent(
+	elements []*extractor.TextElement,
+	columns []float64,
+) []*extractor.TextElement {
+	if len(columns) < 2 {
+		return elements
+	}
+	left, right := columns[0], columns[len(columns)-1]
+	filtered := make([]*extractor.TextElement, 0, len(elements))
+	for _, element := range elements {
+		if center := element.CenterX(); center >= left && center <= right {
+			filtered = append(filtered, element)
+		}
+	}
+	if len(filtered) == 0 {
+		return elements
+	}
+	return filtered
 }
 
 // isValidGrid checks if a grid is valid for table extraction.

--- a/internal/tabledetect/table_detector.go
+++ b/internal/tabledetect/table_detector.go
@@ -328,10 +328,17 @@ func elementsWithinColumnExtent(
 	}
 	left, right := columns[0], columns[len(columns)-1]
 	filtered := make([]*extractor.TextElement, 0, len(elements))
-	for _, element := range elements {
-		if center := element.CenterX(); center >= left && center <= right {
-			filtered = append(filtered, element)
+	for _, row := range NewColumnBoundaryDetector().groupElementsByRow(elements) {
+		inExtent := make([]*extractor.TextElement, 0, len(row))
+		for _, element := range row {
+			if center := element.CenterX(); center >= left && center <= right {
+				inExtent = append(inExtent, element)
+			}
 		}
+		if rowContainsPageNumber(row) && !rowContainsNumericValue(inExtent) {
+			continue
+		}
+		filtered = append(filtered, inExtent...)
 	}
 	if len(filtered) == 0 {
 		return elements

--- a/internal/tabledetect/table_detector_extent_test.go
+++ b/internal/tabledetect/table_detector_extent_test.go
@@ -1,0 +1,25 @@
+package tabledetect
+
+import (
+	"testing"
+
+	"github.com/coregx/gxpdf/internal/extractor"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestElementsWithinColumnExtentExcludesPageText(t *testing.T) {
+	tableLabel := extractor.NewTextElement("Revenue", 20, 100, 50, 10, "F1", 10)
+	tableValue := extractor.NewTextElement("1450", 376, 100, 24, 10, "F1", 10)
+	pageNumber := extractor.NewTextElement("Page 1", 700, 20, 30, 10, "F1", 10)
+
+	got := elementsWithinColumnExtent(
+		[]*extractor.TextElement{tableLabel, tableValue, pageNumber},
+		[]float64{20, 170, 376, 400},
+	)
+
+	assert.Equal(t, []*extractor.TextElement{tableLabel, tableValue}, got)
+}
+
+func TestSupportedRowAdjacencyUsesLowerMedianGap(t *testing.T) {
+	assert.Equal(t, 30.0, supportedRowAdjacency([]float64{80, 100, 200}))
+}

--- a/internal/tabledetect/table_detector_extent_test.go
+++ b/internal/tabledetect/table_detector_extent_test.go
@@ -23,3 +23,65 @@ func TestElementsWithinColumnExtentExcludesPageText(t *testing.T) {
 func TestSupportedRowAdjacencyUsesLowerMedianGap(t *testing.T) {
 	assert.Equal(t, 30.0, supportedRowAdjacency([]float64{80, 100, 200}))
 }
+
+func TestElementsWithinColumnExtentHandlesPageLabels(t *testing.T) {
+	tableLabel := extractor.NewTextElement("Revenue", 20, 100, 50, 10, "F1", 10)
+	tableValue := extractor.NewTextElement("1450", 376, 100, 24, 10, "F1", 10)
+	footerLabel := extractor.NewTextElement("Annual report", 20, 80, 70, 10, "F1", 10)
+	pageNumber := extractor.NewTextElement("Page 1 of 12", 190, 80, 60, 10, "F1", 10)
+	structuredPageLabel := extractor.NewTextElement("Page 1", 20, 80, 40, 10, "F1", 10)
+	structuredPageValue := extractor.NewTextElement("125", 376, 80, 18, 10, "F1", 10)
+
+	tests := []struct {
+		name     string
+		elements []*extractor.TextElement
+		want     []*extractor.TextElement
+	}{
+		{
+			name:     "excludes whole page-number footer",
+			elements: []*extractor.TextElement{tableLabel, tableValue, footerLabel, pageNumber},
+			want:     []*extractor.TextElement{tableLabel, tableValue},
+		},
+		{
+			name:     "keeps structured row whose label starts with Page",
+			elements: []*extractor.TextElement{structuredPageLabel, structuredPageValue},
+			want:     []*extractor.TextElement{structuredPageLabel, structuredPageValue},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := elementsWithinColumnExtent(test.elements, []float64{20, 170, 376, 400})
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestStreamTableKeepsSparseTerminalValueAfterSectionGap(t *testing.T) {
+	elements := []*extractor.TextElement{
+		extractor.NewTextElement("Line Item", 20, 120, 60, 10, "F1", 10),
+		extractor.NewTextElement("2023", 176, 120, 24, 10, "F1", 10),
+		extractor.NewTextElement("Revenue", 20, 100, 50, 10, "F1", 10),
+		extractor.NewTextElement("1200", 176, 100, 24, 10, "F1", 10),
+		extractor.NewTextElement("Cost", 20, 80, 30, 10, "F1", 10),
+		extractor.NewTextElement("(400)", 170, 80, 30, 10, "F1", 10),
+		extractor.NewTextElement("Other", 20, 40, 30, 10, "F1", 10),
+		extractor.NewTextElement("900", 382, 40, 18, 10, "F1", 10),
+	}
+
+	regions, err := NewDefaultTableDetector().DetectTablesStream(elements)
+	assert.NoError(t, err)
+	if assert.Len(t, regions, 1) {
+		table, extractErr := NewTableExtractor(elements).ExtractTable(regions[0])
+		assert.NoError(t, extractErr)
+		found := false
+		for row := range table.RowCount {
+			for column := range table.ColCount {
+				if cell := table.GetCell(row, column); cell != nil && cell.Text == "900" {
+					found = true
+				}
+			}
+		}
+		assert.True(t, found)
+	}
+}

--- a/internal/tabledetect/table_detector_extent_test.go
+++ b/internal/tabledetect/table_detector_extent_test.go
@@ -24,6 +24,32 @@ func TestSupportedRowAdjacencyUsesLowerMedianGap(t *testing.T) {
 	assert.Equal(t, 30.0, supportedRowAdjacency([]float64{80, 100, 200}))
 }
 
+func TestRowContainsNumericValueRecognizesFinancialFormatsConservatively(t *testing.T) {
+	tests := []struct {
+		text string
+		want bool
+	}{
+		{text: "1,234", want: true},
+		{text: "(400)", want: true},
+		{text: "−570", want: true},
+		{text: "€ 1.450,00", want: true},
+		{text: "12.5%", want: true},
+		{text: "Page 1", want: false},
+		{text: "Annual report 2024", want: false},
+		{text: "—", want: false},
+		{text: "K-68", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.text, func(t *testing.T) {
+			row := []*extractor.TextElement{
+				extractor.NewTextElement(test.text, 20, 80, 40, 10, "F1", 10),
+			}
+			assert.Equal(t, test.want, rowContainsNumericValue(row))
+		})
+	}
+}
+
 func TestElementsWithinColumnExtentHandlesPageLabels(t *testing.T) {
 	tableLabel := extractor.NewTextElement("Revenue", 20, 100, 50, 10, "F1", 10)
 	tableValue := extractor.NewTextElement("1450", 376, 100, 24, 10, "F1", 10)

--- a/testdata/generators/form_positioned_table.go
+++ b/testdata/generators/form_positioned_table.go
@@ -1,0 +1,101 @@
+//go:build ignore
+
+// Generator for testdata/pdfs/form_positioned_table.pdf.
+//
+// It mimics PDF generators that place unit-sized glyphs at the text origin and
+// supply their real page position through nested page/Form/glyph transforms.
+// Run from the repository root with:
+//
+//	go run testdata/generators/form_positioned_table.go
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type pdfObject []byte
+
+func main() {
+	formContent := strings.Join([]string{
+		positionedGlyphRun(100, 700, "Income Statement"),
+		positionedGlyphRun(100, 650, "Line Item"),
+		positionedGlyphRun(350, 650, "2023"),
+		positionedGlyphRun(450, 650, "2024"),
+		positionedGlyphRun(100, 620, "Revenue"),
+		positionedGlyphRun(350, 620, "1200"),
+		positionedGlyphRun(450, 620, "1450"),
+		positionedGlyphRun(100, 590, "Cost of Sales"),
+		positionedGlyphRun(350, 590, "(400)"),
+		positionedGlyphRun(450, 590, "(570)"),
+	}, "\n")
+	fontWidths := strings.TrimSpace(strings.Repeat("600 ", 95))
+	pageContent := strings.Join([]string{
+		// A direct-page grid surrounds the three transformed text columns.
+		"50 350 m 270 350 l 270 302 l 50 302 l h S",
+		"170 350 m 170 302 l S",
+		"220 350 m 220 302 l S",
+		"50 332 m 270 332 l S",
+		"50 317 m 270 317 l S",
+		"q 0.5 0 0 0.5 0 0 cm /Fm1 Do Q",
+	}, "\n")
+	objects := []pdfObject{
+		pdfObject("<< /Type /Catalog /Pages 2 0 R >>"),
+		pdfObject("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+		pdfObject("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /Fm1 5 0 R >> >> /Contents 4 0 R >>"),
+		streamObject([]byte(pageContent), ""),
+		streamObject([]byte(formContent), "/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Matrix [1 0 0 1 20 30] /Resources << /Font << /F1 6 0 R >> >>"),
+		pdfObject(fmt.Sprintf("<< /Type /Font /Subtype /TrueType /BaseFont /Synthetic /FirstChar 32 /LastChar 126 /Widths [%s] >>", fontWidths)),
+	}
+	path := filepath.Join("testdata", "pdfs", "form_positioned_table.pdf")
+	if err := os.WriteFile(path, buildPDF(objects), 0o644); err != nil {
+		panic(err)
+	}
+}
+
+func positionedGlyphRun(x, y int, value string) string {
+	var content strings.Builder
+	for _, glyph := range value {
+		fmt.Fprintf(&content, "q 10 0 0 10 %d %d cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (%s) Tj ET Q\n", x, y, escapePDFText(string(glyph)))
+		x += 6
+	}
+	return strings.TrimSpace(content.String())
+}
+
+func streamObject(data []byte, extra string) pdfObject {
+	prefix := fmt.Sprintf("<< %s /Length %d >>\nstream\n", extra, len(data))
+	result := make([]byte, 0, len(prefix)+len(data)+11)
+	result = append(result, prefix...)
+	result = append(result, data...)
+	result = append(result, []byte("\nendstream")...)
+	return result
+}
+
+func buildPDF(objects []pdfObject) []byte {
+	var out bytes.Buffer
+	out.WriteString("%PDF-1.7\n%\xE2\xE3\xCF\xD3\n")
+	offsets := make([]int, len(objects)+1)
+	for index, object := range objects {
+		offsets[index+1] = out.Len()
+		fmt.Fprintf(&out, "%d 0 obj\n", index+1)
+		out.Write(object)
+		out.WriteString("\nendobj\n")
+	}
+	xref := out.Len()
+	fmt.Fprintf(&out, "xref\n0 %d\n", len(objects)+1)
+	out.WriteString("0000000000 65535 f\n")
+	for _, offset := range offsets[1:] {
+		fmt.Fprintf(&out, "%010d 00000 n\n", offset)
+	}
+	fmt.Fprintf(&out, "trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", len(objects)+1, xref)
+	return out.Bytes()
+}
+
+func escapePDFText(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, "(", `\(`)
+	return strings.ReplaceAll(value, ")", `\)`)
+}

--- a/testdata/generators/form_positioned_table.go
+++ b/testdata/generators/form_positioned_table.go
@@ -63,6 +63,32 @@ func main() {
 	if err := os.WriteFile(outlierPath, buildPDF(outlierObjects), 0o644); err != nil {
 		panic(err)
 	}
+
+	footerObjects := append([]pdfObject(nil), objects...)
+	footerContent := formContent + "\n" + positionedGlyphRun(100, 560, "Annual report") + "\n" + positionedGlyphRun(1050, 560, "Page 1")
+	footerObjects[4] = streamObject([]byte(footerContent), "/Type /XObject /Subtype /Form /BBox [0 0 1224 792] /Matrix [1 0 0 1 20 30] /Resources << /Font << /F1 6 0 R >> >>")
+	footerPath := filepath.Join("testdata", "pdfs", "form_positioned_table_near_footer.pdf")
+	if err := os.WriteFile(footerPath, buildPDF(footerObjects), 0o644); err != nil {
+		panic(err)
+	}
+
+	sparseContent := strings.Join([]string{
+		positionedGlyphRun(100, 700, "Income Statement"),
+		positionedGlyphRun(100, 650, "Line Item"),
+		positionedGlyphRun(350, 650, "2023"),
+		positionedGlyphRun(100, 620, "Revenue"),
+		positionedGlyphRun(350, 620, "1200"),
+		positionedGlyphRun(100, 590, "Cost of Sales"),
+		positionedGlyphRun(350, 590, "(400)"),
+		positionedGlyphRun(100, 520, "Other"),
+		positionedGlyphRun(450, 520, "900"),
+	}, "\n")
+	sparseObjects := append([]pdfObject(nil), objects...)
+	sparseObjects[4] = streamObject([]byte(sparseContent), "/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Matrix [1 0 0 1 20 30] /Resources << /Font << /F1 6 0 R >> >>")
+	sparsePath := filepath.Join("testdata", "pdfs", "form_positioned_table_sparse_section.pdf")
+	if err := os.WriteFile(sparsePath, buildPDF(sparseObjects), 0o644); err != nil {
+		panic(err)
+	}
 }
 
 func positionedGlyphRun(x, y int, value string) string {

--- a/testdata/generators/form_positioned_table.go
+++ b/testdata/generators/form_positioned_table.go
@@ -1,6 +1,7 @@
 //go:build ignore
 
-// Generator for testdata/pdfs/form_positioned_table.pdf.
+// Generator for testdata/pdfs/form_positioned_table.pdf and its far-right
+// page-text outlier variant.
 //
 // It mimics PDF generators that place unit-sized glyphs at the text origin and
 // supply their real page position through nested page/Form/glyph transforms.
@@ -52,6 +53,14 @@ func main() {
 	}
 	path := filepath.Join("testdata", "pdfs", "form_positioned_table.pdf")
 	if err := os.WriteFile(path, buildPDF(objects), 0o644); err != nil {
+		panic(err)
+	}
+
+	outlierObjects := append([]pdfObject(nil), objects...)
+	outlierContent := formContent + "\n" + positionedGlyphRun(1050, 100, "Page 1")
+	outlierObjects[4] = streamObject([]byte(outlierContent), "/Type /XObject /Subtype /Form /BBox [0 0 1224 792] /Matrix [1 0 0 1 20 30] /Resources << /Font << /F1 6 0 R >> >>")
+	outlierPath := filepath.Join("testdata", "pdfs", "form_positioned_table_outlier.pdf")
+	if err := os.WriteFile(outlierPath, buildPDF(outlierObjects), 0o644); err != nil {
 		panic(err)
 	}
 }

--- a/testdata/golden/form_positioned_table_stream_table0.json
+++ b/testdata/golden/form_positioned_table_stream_table0.json
@@ -1,0 +1,79 @@
+{
+  "pdf": "testdata/pdfs/form_positioned_table.pdf",
+  "page": 0,
+  "method": "Stream",
+  "rows": 4,
+  "cols": 3,
+  "cells": [
+    {
+      "row": 0,
+      "col": 0,
+      "text": "Income Statement",
+      "rowSpan": 1,
+      "colSpan": 1
+    },
+    {
+      "row": 1,
+      "col": 0,
+      "text": "Line Item",
+      "rowSpan": 1,
+      "colSpan": 1
+    },
+    {
+      "row": 1,
+      "col": 1,
+      "text": "2023",
+      "rowSpan": 1,
+      "colSpan": 1
+    },
+    {
+      "row": 1,
+      "col": 2,
+      "text": "2024",
+      "rowSpan": 1,
+      "colSpan": 1
+    },
+    {
+      "row": 2,
+      "col": 0,
+      "text": "Revenue",
+      "rowSpan": 1,
+      "colSpan": 1
+    },
+    {
+      "row": 2,
+      "col": 1,
+      "text": "1200",
+      "rowSpan": 1,
+      "colSpan": 1
+    },
+    {
+      "row": 2,
+      "col": 2,
+      "text": "1450",
+      "rowSpan": 1,
+      "colSpan": 1
+    },
+    {
+      "row": 3,
+      "col": 0,
+      "text": "Cost of Sales",
+      "rowSpan": 1,
+      "colSpan": 1
+    },
+    {
+      "row": 3,
+      "col": 1,
+      "text": "(400)",
+      "rowSpan": 1,
+      "colSpan": 1
+    },
+    {
+      "row": 3,
+      "col": 2,
+      "text": "(570)",
+      "rowSpan": 1,
+      "colSpan": 1
+    }
+  ]
+}

--- a/testdata/pdfs/form_positioned_table.pdf
+++ b/testdata/pdfs/form_positioned_table.pdf
@@ -1,0 +1,115 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /Fm1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<<  /Length 158 >>
+stream
+50 350 m 270 350 l 270 302 l 50 302 l h S
+170 350 m 170 302 l S
+220 350 m 220 302 l S
+50 332 m 270 332 l S
+50 317 m 270 317 l S
+q 0.5 0 0 0.5 0 0 cm /Fm1 Do Q
+endstream
+endobj
+5 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 612 792] /Matrix [1 0 0 1 20 30] /Resources << /Font << /F1 6 0 R >> >> /Length 4405 >>
+stream
+q 10 0 0 10 100 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (I) Tj ET Q
+q 10 0 0 10 106 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 112 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (c) Tj ET Q
+q 10 0 0 10 118 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (o) Tj ET Q
+q 10 0 0 10 124 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (m) Tj ET Q
+q 10 0 0 10 130 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 136 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 142 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (S) Tj ET Q
+q 10 0 0 10 148 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 154 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (a) Tj ET Q
+q 10 0 0 10 160 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 166 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 172 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (m) Tj ET Q
+q 10 0 0 10 178 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 184 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 190 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 100 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (L) Tj ET Q
+q 10 0 0 10 106 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (i) Tj ET Q
+q 10 0 0 10 112 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 118 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 124 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 130 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (I) Tj ET Q
+q 10 0 0 10 136 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 142 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 148 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (m) Tj ET Q
+q 10 0 0 10 350 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 356 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 362 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 368 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (3) Tj ET Q
+q 10 0 0 10 450 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 456 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 462 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 468 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (4) Tj ET Q
+q 10 0 0 10 100 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (R) Tj ET Q
+q 10 0 0 10 106 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 112 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (v) Tj ET Q
+q 10 0 0 10 118 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 124 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 130 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (u) Tj ET Q
+q 10 0 0 10 136 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 350 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (1) Tj ET Q
+q 10 0 0 10 356 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 362 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 368 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 450 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (1) Tj ET Q
+q 10 0 0 10 456 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (4) Tj ET Q
+q 10 0 0 10 462 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (5) Tj ET Q
+q 10 0 0 10 468 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 100 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (C) Tj ET Q
+q 10 0 0 10 106 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (o) Tj ET Q
+q 10 0 0 10 112 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (s) Tj ET Q
+q 10 0 0 10 118 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 124 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 130 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (o) Tj ET Q
+q 10 0 0 10 136 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (f) Tj ET Q
+q 10 0 0 10 142 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 148 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (S) Tj ET Q
+q 10 0 0 10 154 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (a) Tj ET Q
+q 10 0 0 10 160 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (l) Tj ET Q
+q 10 0 0 10 166 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 172 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (s) Tj ET Q
+q 10 0 0 10 350 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\() Tj ET Q
+q 10 0 0 10 356 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (4) Tj ET Q
+q 10 0 0 10 362 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 368 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 374 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\)) Tj ET Q
+q 10 0 0 10 450 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\() Tj ET Q
+q 10 0 0 10 456 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (5) Tj ET Q
+q 10 0 0 10 462 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (7) Tj ET Q
+q 10 0 0 10 468 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 474 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\)) Tj ET Q
+endstream
+endobj
+6 0 obj
+<< /Type /Font /Subtype /TrueType /BaseFont /Synthetic /FirstChar 32 /LastChar 126 /Widths [600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600] >>
+endobj
+xref
+0 7
+0000000000 65535 f
+0000000015 00000 n
+0000000064 00000 n
+0000000121 00000 n
+0000000251 00000 n
+0000000461 00000 n
+0000005031 00000 n
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+5522
+%%EOF

--- a/testdata/pdfs/form_positioned_table_near_footer.pdf
+++ b/testdata/pdfs/form_positioned_table_near_footer.pdf
@@ -1,0 +1,134 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /Fm1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<<  /Length 158 >>
+stream
+50 350 m 270 350 l 270 302 l 50 302 l h S
+170 350 m 170 302 l S
+220 350 m 220 302 l S
+50 332 m 270 332 l S
+50 317 m 270 317 l S
+q 0.5 0 0 0.5 0 0 cm /Fm1 Do Q
+endstream
+endobj
+5 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 1224 792] /Matrix [1 0 0 1 20 30] /Resources << /Font << /F1 6 0 R >> >> /Length 5589 >>
+stream
+q 10 0 0 10 100 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (I) Tj ET Q
+q 10 0 0 10 106 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 112 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (c) Tj ET Q
+q 10 0 0 10 118 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (o) Tj ET Q
+q 10 0 0 10 124 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (m) Tj ET Q
+q 10 0 0 10 130 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 136 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 142 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (S) Tj ET Q
+q 10 0 0 10 148 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 154 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (a) Tj ET Q
+q 10 0 0 10 160 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 166 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 172 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (m) Tj ET Q
+q 10 0 0 10 178 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 184 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 190 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 100 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (L) Tj ET Q
+q 10 0 0 10 106 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (i) Tj ET Q
+q 10 0 0 10 112 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 118 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 124 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 130 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (I) Tj ET Q
+q 10 0 0 10 136 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 142 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 148 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (m) Tj ET Q
+q 10 0 0 10 350 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 356 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 362 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 368 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (3) Tj ET Q
+q 10 0 0 10 450 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 456 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 462 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 468 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (4) Tj ET Q
+q 10 0 0 10 100 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (R) Tj ET Q
+q 10 0 0 10 106 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 112 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (v) Tj ET Q
+q 10 0 0 10 118 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 124 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 130 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (u) Tj ET Q
+q 10 0 0 10 136 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 350 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (1) Tj ET Q
+q 10 0 0 10 356 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 362 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 368 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 450 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (1) Tj ET Q
+q 10 0 0 10 456 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (4) Tj ET Q
+q 10 0 0 10 462 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (5) Tj ET Q
+q 10 0 0 10 468 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 100 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (C) Tj ET Q
+q 10 0 0 10 106 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (o) Tj ET Q
+q 10 0 0 10 112 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (s) Tj ET Q
+q 10 0 0 10 118 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 124 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 130 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (o) Tj ET Q
+q 10 0 0 10 136 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (f) Tj ET Q
+q 10 0 0 10 142 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 148 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (S) Tj ET Q
+q 10 0 0 10 154 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (a) Tj ET Q
+q 10 0 0 10 160 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (l) Tj ET Q
+q 10 0 0 10 166 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 172 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (s) Tj ET Q
+q 10 0 0 10 350 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\() Tj ET Q
+q 10 0 0 10 356 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (4) Tj ET Q
+q 10 0 0 10 362 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 368 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 374 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\)) Tj ET Q
+q 10 0 0 10 450 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\() Tj ET Q
+q 10 0 0 10 456 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (5) Tj ET Q
+q 10 0 0 10 462 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (7) Tj ET Q
+q 10 0 0 10 468 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 474 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\)) Tj ET Q
+q 10 0 0 10 100 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (A) Tj ET Q
+q 10 0 0 10 106 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 112 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 118 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (u) Tj ET Q
+q 10 0 0 10 124 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (a) Tj ET Q
+q 10 0 0 10 130 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (l) Tj ET Q
+q 10 0 0 10 136 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 142 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (r) Tj ET Q
+q 10 0 0 10 148 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 154 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (p) Tj ET Q
+q 10 0 0 10 160 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (o) Tj ET Q
+q 10 0 0 10 166 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (r) Tj ET Q
+q 10 0 0 10 172 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 1050 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (P) Tj ET Q
+q 10 0 0 10 1056 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (a) Tj ET Q
+q 10 0 0 10 1062 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (g) Tj ET Q
+q 10 0 0 10 1068 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 1074 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 1080 560 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (1) Tj ET Q
+endstream
+endobj
+6 0 obj
+<< /Type /Font /Subtype /TrueType /BaseFont /Synthetic /FirstChar 32 /LastChar 126 /Widths [600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600] >>
+endobj
+xref
+0 7
+0000000000 65535 f
+0000000015 00000 n
+0000000064 00000 n
+0000000121 00000 n
+0000000251 00000 n
+0000000461 00000 n
+0000006216 00000 n
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+6707
+%%EOF

--- a/testdata/pdfs/form_positioned_table_outlier.pdf
+++ b/testdata/pdfs/form_positioned_table_outlier.pdf
@@ -1,0 +1,121 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /Fm1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<<  /Length 158 >>
+stream
+50 350 m 270 350 l 270 302 l 50 302 l h S
+170 350 m 170 302 l S
+220 350 m 220 302 l S
+50 332 m 270 332 l S
+50 317 m 270 317 l S
+q 0.5 0 0 0.5 0 0 cm /Fm1 Do Q
+endstream
+endobj
+5 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 1224 792] /Matrix [1 0 0 1 20 30] /Resources << /Font << /F1 6 0 R >> >> /Length 4783 >>
+stream
+q 10 0 0 10 100 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (I) Tj ET Q
+q 10 0 0 10 106 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 112 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (c) Tj ET Q
+q 10 0 0 10 118 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (o) Tj ET Q
+q 10 0 0 10 124 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (m) Tj ET Q
+q 10 0 0 10 130 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 136 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 142 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (S) Tj ET Q
+q 10 0 0 10 148 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 154 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (a) Tj ET Q
+q 10 0 0 10 160 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 166 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 172 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (m) Tj ET Q
+q 10 0 0 10 178 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 184 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 190 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 100 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (L) Tj ET Q
+q 10 0 0 10 106 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (i) Tj ET Q
+q 10 0 0 10 112 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 118 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 124 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 130 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (I) Tj ET Q
+q 10 0 0 10 136 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 142 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 148 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (m) Tj ET Q
+q 10 0 0 10 350 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 356 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 362 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 368 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (3) Tj ET Q
+q 10 0 0 10 450 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 456 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 462 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 468 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (4) Tj ET Q
+q 10 0 0 10 100 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (R) Tj ET Q
+q 10 0 0 10 106 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 112 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (v) Tj ET Q
+q 10 0 0 10 118 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 124 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 130 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (u) Tj ET Q
+q 10 0 0 10 136 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 350 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (1) Tj ET Q
+q 10 0 0 10 356 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 362 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 368 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 450 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (1) Tj ET Q
+q 10 0 0 10 456 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (4) Tj ET Q
+q 10 0 0 10 462 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (5) Tj ET Q
+q 10 0 0 10 468 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 100 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (C) Tj ET Q
+q 10 0 0 10 106 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (o) Tj ET Q
+q 10 0 0 10 112 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (s) Tj ET Q
+q 10 0 0 10 118 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 124 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 130 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (o) Tj ET Q
+q 10 0 0 10 136 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (f) Tj ET Q
+q 10 0 0 10 142 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 148 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (S) Tj ET Q
+q 10 0 0 10 154 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (a) Tj ET Q
+q 10 0 0 10 160 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (l) Tj ET Q
+q 10 0 0 10 166 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 172 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (s) Tj ET Q
+q 10 0 0 10 350 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\() Tj ET Q
+q 10 0 0 10 356 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (4) Tj ET Q
+q 10 0 0 10 362 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 368 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 374 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\)) Tj ET Q
+q 10 0 0 10 450 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\() Tj ET Q
+q 10 0 0 10 456 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (5) Tj ET Q
+q 10 0 0 10 462 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (7) Tj ET Q
+q 10 0 0 10 468 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 474 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\)) Tj ET Q
+q 10 0 0 10 1050 100 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (P) Tj ET Q
+q 10 0 0 10 1056 100 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (a) Tj ET Q
+q 10 0 0 10 1062 100 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (g) Tj ET Q
+q 10 0 0 10 1068 100 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 1074 100 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 1080 100 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (1) Tj ET Q
+endstream
+endobj
+6 0 obj
+<< /Type /Font /Subtype /TrueType /BaseFont /Synthetic /FirstChar 32 /LastChar 126 /Widths [600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600] >>
+endobj
+xref
+0 7
+0000000000 65535 f
+0000000015 00000 n
+0000000064 00000 n
+0000000121 00000 n
+0000000251 00000 n
+0000000461 00000 n
+0000005410 00000 n
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+5901
+%%EOF

--- a/testdata/pdfs/form_positioned_table_sparse_section.pdf
+++ b/testdata/pdfs/form_positioned_table_sparse_section.pdf
@@ -1,0 +1,110 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /Fm1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<<  /Length 158 >>
+stream
+50 350 m 270 350 l 270 302 l 50 302 l h S
+170 350 m 170 302 l S
+220 350 m 220 302 l S
+50 332 m 270 332 l S
+50 317 m 270 317 l S
+q 0.5 0 0 0.5 0 0 cm /Fm1 Do Q
+endstream
+endobj
+5 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 612 792] /Matrix [1 0 0 1 20 30] /Resources << /Font << /F1 6 0 R >> >> /Length 4093 >>
+stream
+q 10 0 0 10 100 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (I) Tj ET Q
+q 10 0 0 10 106 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 112 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (c) Tj ET Q
+q 10 0 0 10 118 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (o) Tj ET Q
+q 10 0 0 10 124 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (m) Tj ET Q
+q 10 0 0 10 130 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 136 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 142 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (S) Tj ET Q
+q 10 0 0 10 148 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 154 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (a) Tj ET Q
+q 10 0 0 10 160 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 166 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 172 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (m) Tj ET Q
+q 10 0 0 10 178 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 184 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 190 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 100 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (L) Tj ET Q
+q 10 0 0 10 106 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (i) Tj ET Q
+q 10 0 0 10 112 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 118 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 124 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 130 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (I) Tj ET Q
+q 10 0 0 10 136 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 142 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 148 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (m) Tj ET Q
+q 10 0 0 10 350 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 356 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 362 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 368 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (3) Tj ET Q
+q 10 0 0 10 100 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (R) Tj ET Q
+q 10 0 0 10 106 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 112 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (v) Tj ET Q
+q 10 0 0 10 118 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 124 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 130 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (u) Tj ET Q
+q 10 0 0 10 136 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 350 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (1) Tj ET Q
+q 10 0 0 10 356 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 362 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 368 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 100 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (C) Tj ET Q
+q 10 0 0 10 106 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (o) Tj ET Q
+q 10 0 0 10 112 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (s) Tj ET Q
+q 10 0 0 10 118 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 124 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 130 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (o) Tj ET Q
+q 10 0 0 10 136 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (f) Tj ET Q
+q 10 0 0 10 142 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 148 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (S) Tj ET Q
+q 10 0 0 10 154 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (a) Tj ET Q
+q 10 0 0 10 160 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (l) Tj ET Q
+q 10 0 0 10 166 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 172 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (s) Tj ET Q
+q 10 0 0 10 350 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\() Tj ET Q
+q 10 0 0 10 356 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (4) Tj ET Q
+q 10 0 0 10 362 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 368 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 374 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\)) Tj ET Q
+q 10 0 0 10 100 520 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (O) Tj ET Q
+q 10 0 0 10 106 520 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 112 520 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (h) Tj ET Q
+q 10 0 0 10 118 520 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 124 520 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (r) Tj ET Q
+q 10 0 0 10 450 520 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (9) Tj ET Q
+q 10 0 0 10 456 520 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 462 520 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+endstream
+endobj
+6 0 obj
+<< /Type /Font /Subtype /TrueType /BaseFont /Synthetic /FirstChar 32 /LastChar 126 /Widths [600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600] >>
+endobj
+xref
+0 7
+0000000000 65535 f
+0000000015 00000 n
+0000000064 00000 n
+0000000121 00000 n
+0000000251 00000 n
+0000000461 00000 n
+0000004719 00000 n
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+5210
+%%EOF


### PR DESCRIPTION
## Summary

- complete Stream-mode boundaries with the outer extent of structurally supported table rows so a populated terminal column keeps its right edge
- preserve a sparse terminal value after a genuine section gap without broadening the acceptance of unrelated labels
- reject page-level outliers, including standalone page numbers, nearby title/page-number metadata rows, and centered page markers, before they can create phantom columns or rows
- preserve legitimate structured rows whose label begins with `Page` when the row also contains table values
- compact whitespace-only intervals produced when edge clustering selects both sides of an inter-column gap
- snap clustered outer edges to the supported extent instead of creating sub-gap phantom columns
- treat text centers exactly on a candidate edge as evidence that the edge cuts text, not that the following interval is populated

Fixes #94.

## Dependency

This draft depends on #90. Once #90 lands, GitHub will reduce this PR to its table-boundary commits automatically.

## Scope

This PR fixes terminal-boundary selection and nearby page-metadata contamination in Stream reconstruction. It does not attempt a general redesign of table segmentation or financial-statement row reconstruction.

## Test coverage

- table-driven boundary compaction tests, including sparse columns and already-compact input
- sparse financial values in integer, European currency, parenthesized-negative, and Unicode-minus forms
- right-aligned 2-, 3-, and 4-value-column matrices, including parenthesized values and a missing cell
- table-driven nearby and far-right page-metadata coverage
- a legitimate `Page`-label row proving that metadata filtering does not discard structured table content
- exact public `ExtractTablesWithOptions` assertions for Auto, Stream, Lattice, and Hybrid methods
- public fixtures proving a nearby footer does not add a table row or column and a sparse value after a section gap remains in the terminal column
- Stream golden snapshot for every populated cell, including the rightmost `2024`, `1450`, and `(570)` values
- deterministic generators for the base, outlier, nearby-footer, and sparse-section PDF fixtures

## Verification

- `GOTOOLCHAIN=go1.25.7 go vet ./...`
- `GOTOOLCHAIN=go1.25.7 go test -race ./...`
- `golangci-lint v2.11.0 run --timeout=5m`
- formatting and diff checks
- Linux/386 cross-build
