### PR TITLE
fix: unify Form text geometry across font sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Form XObject text geometry** — compose page `cm`, Form `/Matrix`, and nested glyph transforms for unit-sized positioned text; isolate Form graphics state, use embedded font widths, and bound hostile composite `/W` ranges (#89)
+
 ---
 
 ## [0.9.4] - 2026-08-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Form XObject text geometry** — compose page `cm`, Form `/Matrix`, and nested glyph transforms for unit-sized positioned text; isolate Form graphics state, use embedded font widths, and bound hostile composite `/W` ranges (#89)
+- **Form XObject text geometry at all font sizes** — apply the same accumulated transformations above and below the former two-unit compatibility threshold (#96)
 
 ---
 

--- a/form_positioned_table_test.go
+++ b/form_positioned_table_test.go
@@ -1,0 +1,48 @@
+package gxpdf
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestFormPositionedGeometryReachesTableDetection verifies the public handoff:
+// corrected Form glyph geometry must reach the table detector instead of leaving
+// a native-text table undiscoverable. Exact multi-column reconstruction is a
+// separate concern and is intentionally not frozen by this regression test.
+func TestFormPositionedGeometryReachesTableDetection(t *testing.T) {
+	methods := []ExtractionMethod{MethodAuto, MethodStream, MethodLattice, MethodHybrid}
+	for _, method := range methods {
+		t.Run(method.String(), func(t *testing.T) {
+			document, err := Open(filepath.Join("testdata", "pdfs", "form_positioned_table.pdf"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer document.Close()
+
+			tables, err := document.ExtractTablesWithOptions(DefaultExtractionOptions().WithMethod(method))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(tables) != 1 {
+				t.Fatalf("tables = %d, want 1", len(tables))
+			}
+			rows := tables[0].Rows()
+			for _, label := range []string{"Line Item", "Revenue", "Cost of Sales"} {
+				if !tableContainsText(rows, label) {
+					t.Errorf("table does not contain %q: %#v", label, rows)
+				}
+			}
+		})
+	}
+}
+
+func tableContainsText(rows [][]string, want string) bool {
+	for _, row := range rows {
+		for _, cell := range row {
+			if cell == want {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/form_positioned_table_test.go
+++ b/form_positioned_table_test.go
@@ -28,7 +28,7 @@ func TestFormPositionedGeometryReachesTableDetection(t *testing.T) {
 			}
 			rows := tables[0].Rows()
 			for _, label := range []string{"Line Item", "Revenue", "Cost of Sales"} {
-				if !tableContainsText(rows, label) {
+				if !formTableContainsText(rows, label) {
 					t.Errorf("table does not contain %q: %#v", label, rows)
 				}
 			}
@@ -36,7 +36,7 @@ func TestFormPositionedGeometryReachesTableDetection(t *testing.T) {
 	}
 }
 
-func tableContainsText(rows [][]string, want string) bool {
+func formTableContainsText(rows [][]string, want string) bool {
 	for _, row := range rows {
 		for _, cell := range row {
 			if cell == want {

--- a/form_text_sizes_test.go
+++ b/form_text_sizes_test.go
@@ -1,0 +1,50 @@
+package gxpdf
+
+import (
+	"math"
+	"path/filepath"
+	"testing"
+)
+
+func TestFormTextGeometryIsIndependentOfFontSizeThreshold(t *testing.T) {
+	document, err := Open(filepath.Join("testdata", "pdfs", "form_text_sizes.pdf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer document.Close()
+
+	elements, err := document.ExtractTextElementsFromPage(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]struct {
+		x, y, width, height, fontSize float64
+	}{
+		"A": {115, 210, 0.6, 1.5, 1.5},
+		"B": {115, 270, 1.2, 3, 3},
+		"C": {115, 330, 1.206, 3.015, 3.015},
+		"D": {115, 390, 7.2, 18, 18},
+	}
+	if len(elements) != len(want) {
+		t.Fatalf("elements = %d, want %d: %#v", len(elements), len(want), elements)
+	}
+	for _, element := range elements {
+		expected, ok := want[element.Text]
+		if !ok {
+			t.Errorf("unexpected text element %q", element.Text)
+			continue
+		}
+		assertNear(t, "X", element.X, expected.x)
+		assertNear(t, "Y", element.Y, expected.y)
+		assertNear(t, "Width", element.Width, expected.width)
+		assertNear(t, "Height", element.Height, expected.height)
+		assertNear(t, "FontSize", element.FontSize, expected.fontSize)
+	}
+}
+
+func assertNear(t *testing.T, field string, got, want float64) {
+	t.Helper()
+	if math.Abs(got-want) > 0.001 {
+		t.Errorf("%s = %.6f, want %.6f", field, got, want)
+	}
+}

--- a/form_text_sizes_test.go
+++ b/form_text_sizes_test.go
@@ -28,10 +28,22 @@ func TestFormTextGeometryIsIndependentOfFontSizeThreshold(t *testing.T) {
 	if len(elements) != len(want) {
 		t.Fatalf("elements = %d, want %d: %#v", len(elements), len(want), elements)
 	}
+	actual := make(map[string]TextElement, len(elements))
 	for _, element := range elements {
-		expected, ok := want[element.Text]
-		if !ok {
+		if _, ok := want[element.Text]; !ok {
 			t.Errorf("unexpected text element %q", element.Text)
+			continue
+		}
+		if _, duplicate := actual[element.Text]; duplicate {
+			t.Errorf("duplicate text element %q", element.Text)
+			continue
+		}
+		actual[element.Text] = element
+	}
+	for text, expected := range want {
+		element, ok := actual[text]
+		if !ok {
+			t.Errorf("missing text element %q", text)
 			continue
 		}
 		assertNear(t, "X", element.X, expected.x)

--- a/gxpdf_golden_test.go
+++ b/gxpdf_golden_test.go
@@ -319,3 +319,22 @@ func TestGolden_Issue79_AutoMode(t *testing.T) {
 		opts,
 	)
 }
+
+// TestGolden_FormLargeText_Table snapshots a ruled table whose 12-point text
+// lives inside a Form XObject while the ruling lines live on the page. This
+// freezes the public table handoff above the former two-unit compatibility
+// threshold; the snapshot is intentionally reviewed independently from text
+// geometry assertions.
+func TestGolden_FormLargeText_Table(t *testing.T) {
+	opts := DefaultExtractionOptions().
+		WithMethod(MethodLattice).
+		WithPages(0)
+
+	runGoldenTest(t,
+		"form_large_text_table0",
+		"testdata/pdfs/form_large_text_table.pdf",
+		0,
+		0,
+		opts,
+	)
+}

--- a/internal/extractor/font_extractor.go
+++ b/internal/extractor/font_extractor.go
@@ -172,7 +172,7 @@ func (fe *FontExtractor) extractFontData(fontDict *parser.Dictionary) (*Embedded
 	var err error
 
 	switch subtype {
-	case "Type0":
+	case type0FontSubtype:
 		// Composite font: descriptor lives inside DescendantFonts.
 		descriptorDict, err = fe.descriptorFromType0(fontDict)
 		if err != nil || descriptorDict == nil {

--- a/internal/extractor/font_extractor.go
+++ b/internal/extractor/font_extractor.go
@@ -268,7 +268,7 @@ func (fe *FontExtractor) fontFileData(descriptor *parser.Dictionary) ([]byte, er
 
 // resolveDict resolves an indirect reference and casts to *parser.Dictionary.
 func (fe *FontExtractor) resolveDict(obj parser.PdfObject) (*parser.Dictionary, error) {
-	obj = fe.resolve(obj)
+	obj = resolveObject(fe.reader, obj)
 	if obj == nil {
 		return nil, nil
 	}
@@ -281,7 +281,7 @@ func (fe *FontExtractor) resolveDict(obj parser.PdfObject) (*parser.Dictionary, 
 
 // resolveArray resolves an indirect reference and casts to *parser.Array.
 func (fe *FontExtractor) resolveArray(obj parser.PdfObject) (*parser.Array, error) {
-	obj = fe.resolve(obj)
+	obj = resolveObject(fe.reader, obj)
 	if obj == nil {
 		return nil, nil
 	}
@@ -294,7 +294,7 @@ func (fe *FontExtractor) resolveArray(obj parser.PdfObject) (*parser.Array, erro
 
 // resolveStream resolves an indirect reference and casts to *parser.Stream.
 func (fe *FontExtractor) resolveStream(obj parser.PdfObject) (*parser.Stream, error) {
-	obj = fe.resolve(obj)
+	obj = resolveObject(fe.reader, obj)
 	if obj == nil {
 		return nil, nil
 	}
@@ -303,20 +303,6 @@ func (fe *FontExtractor) resolveStream(obj parser.PdfObject) (*parser.Stream, er
 		return nil, nil
 	}
 	return stream, nil
-}
-
-// resolve follows a single indirect reference using the reader's object table.
-// Non-reference objects are returned as-is. Returns nil on resolution error.
-func (fe *FontExtractor) resolve(obj parser.PdfObject) parser.PdfObject {
-	ref, ok := obj.(*parser.IndirectReference)
-	if !ok {
-		return obj
-	}
-	resolved, err := fe.reader.GetObject(ref.Number)
-	if err != nil {
-		return nil
-	}
-	return resolved
 }
 
 // nameValue extracts the string value from a *parser.Name object.
@@ -353,7 +339,7 @@ func (fe *FontExtractor) encodingValue(obj parser.PdfObject) string {
 	if obj == nil {
 		return ""
 	}
-	obj = fe.resolve(obj)
+	obj = resolveObject(fe.reader, obj)
 	if obj == nil {
 		return ""
 	}

--- a/internal/extractor/font_metrics.go
+++ b/internal/extractor/font_metrics.go
@@ -125,7 +125,7 @@ func (te *TextExtractor) loadCompositeFontMetrics(fontDict *parser.Dictionary) *
 		if !ok {
 			break
 		}
-		first := int(firstObj.Value())
+		first := firstObj.Value()
 		i++
 		if i >= widths.Len() {
 			break
@@ -133,8 +133,9 @@ func (te *TextExtractor) loadCompositeFontMetrics(fontDict *parser.Dictionary) *
 
 		if explicit, ok := te.resolveObject(widths.Get(i)).(*parser.Array); ok {
 			for offset := 0; offset < explicit.Len(); offset++ {
-				if width := getNumber(explicit.Get(offset)); width != nil && first+offset >= 0 && first+offset <= 65535 {
-					metrics.widths[uint16(first+offset)] = *width
+				glyphID := first + int64(offset)
+				if width := getNumber(explicit.Get(offset)); width != nil && glyphID >= 0 && glyphID <= 65535 {
+					metrics.widths[uint16(glyphID)] = *width
 				}
 			}
 			i++
@@ -149,11 +150,18 @@ func (te *TextExtractor) loadCompositeFontMetrics(fontDict *parser.Dictionary) *
 		if width == nil {
 			break
 		}
-		last := int(lastObj.Value())
-		for glyphID := first; glyphID <= last && glyphID <= 65535; glyphID++ {
-			if glyphID >= 0 {
-				metrics.widths[uint16(glyphID)] = *width
-			}
+		last := lastObj.Value()
+		// CID values are unsigned 16-bit identifiers. Clamp both ends before
+		// iterating so a hostile negative cFirst cannot turn a malformed /W
+		// range into billions of no-op loop iterations.
+		if first < 0 {
+			first = 0
+		}
+		if last > 65535 {
+			last = 65535
+		}
+		for glyphID := first; glyphID <= last; glyphID++ {
+			metrics.widths[uint16(glyphID)] = *width
 		}
 		i += 2
 	}

--- a/internal/extractor/font_metrics.go
+++ b/internal/extractor/font_metrics.go
@@ -1,0 +1,172 @@
+package extractor
+
+import "github.com/coregx/gxpdf/internal/parser"
+
+const type0FontSubtype = "Type0"
+
+// fontMetrics contains glyph advances in the PDF's standard 1000-unit text
+// space. Simple fonts define /FirstChar and /Widths; composite Type0 fonts
+// define /DW and /W on their descendant CIDFont.
+type fontMetrics struct {
+	widths       map[uint16]float64
+	defaultWidth float64
+	precise      bool
+}
+
+func (fm *fontMetrics) width(glyphID uint16) float64 {
+	if fm == nil {
+		return 600
+	}
+	if width, ok := fm.widths[glyphID]; ok {
+		return width
+	}
+	return fm.defaultWidth
+}
+
+// measureGlyphBytes returns the text advance, visible width, and whether the
+// width came from authoritative PDF font metrics.
+func (te *TextExtractor) measureGlyphBytes(glyphBytes []byte) (float64, float64, bool) {
+	decoder := te.fontDecoders[te.textState.FontName]
+	metrics := te.fontMetrics[te.textState.FontName]
+	horizontalScale := te.textState.HorizScale / 100.0
+
+	advance := 0.0
+	visibleWidth := 0.0
+	for position := 0; position < len(glyphBytes); {
+		glyphID, bytesRead := uint16(glyphBytes[position]), 1
+		if decoder != nil {
+			glyphID, bytesRead = decoder.readGlyphID(glyphBytes[position:])
+		}
+		if bytesRead <= 0 {
+			break
+		}
+
+		glyphWidth := metrics.width(glyphID) / 1000.0 * te.textState.FontSize * horizontalScale
+		visibleWidth = advance + glyphWidth
+
+		spacing := te.textState.CharSpace
+		if glyphID == 32 && (decoder == nil || !decoder.isCompositeFont) {
+			spacing += te.textState.WordSpace
+		}
+		advance = visibleWidth + spacing*horizontalScale
+		position += bytesRead
+	}
+
+	return advance, visibleWidth, metrics != nil && metrics.precise
+}
+
+func (te *TextExtractor) loadFontMetrics(fontDict *parser.Dictionary) *fontMetrics {
+	if fontDict == nil {
+		return nil
+	}
+
+	if subtype, ok := fontDict.Get("Subtype").(*parser.Name); ok && subtype.Value() == type0FontSubtype {
+		return te.loadCompositeFontMetrics(fontDict)
+	}
+	return te.loadSimpleFontMetrics(fontDict)
+}
+
+func (te *TextExtractor) loadSimpleFontMetrics(fontDict *parser.Dictionary) *fontMetrics {
+	firstCharObj, ok := fontDict.Get("FirstChar").(*parser.Integer)
+	if !ok {
+		return nil
+	}
+	widthsObj := te.resolveObject(fontDict.Get("Widths"))
+	widthsArray, ok := widthsObj.(*parser.Array)
+	if !ok || widthsArray.Len() == 0 {
+		return nil
+	}
+
+	metrics := &fontMetrics{
+		widths:       make(map[uint16]float64, widthsArray.Len()),
+		defaultWidth: 600,
+		precise:      true,
+	}
+	firstChar := int(firstCharObj.Value())
+	for i := 0; i < widthsArray.Len(); i++ {
+		if width := getNumber(widthsArray.Get(i)); width != nil && firstChar+i >= 0 && firstChar+i <= 65535 {
+			metrics.widths[uint16(firstChar+i)] = *width
+		}
+	}
+
+	if descriptor, ok := te.resolveObject(fontDict.Get("FontDescriptor")).(*parser.Dictionary); ok {
+		if missingWidth := getNumber(descriptor.Get("MissingWidth")); missingWidth != nil {
+			metrics.defaultWidth = *missingWidth
+		}
+	}
+	return metrics
+}
+
+func (te *TextExtractor) loadCompositeFontMetrics(fontDict *parser.Dictionary) *fontMetrics {
+	descendants, ok := te.resolveObject(fontDict.Get("DescendantFonts")).(*parser.Array)
+	if !ok || descendants.Len() == 0 {
+		return nil
+	}
+	descendant, ok := te.resolveObject(descendants.Get(0)).(*parser.Dictionary)
+	if !ok {
+		return nil
+	}
+
+	metrics := &fontMetrics{
+		widths:       make(map[uint16]float64),
+		defaultWidth: 1000,
+		precise:      true,
+	}
+	if defaultWidth := getNumber(descendant.Get("DW")); defaultWidth != nil {
+		metrics.defaultWidth = *defaultWidth
+	}
+	widths, _ := te.resolveObject(descendant.Get("W")).(*parser.Array)
+	if widths == nil {
+		return metrics
+	}
+
+	for i := 0; i < widths.Len(); {
+		firstObj, ok := widths.Get(i).(*parser.Integer)
+		if !ok {
+			break
+		}
+		first := int(firstObj.Value())
+		i++
+		if i >= widths.Len() {
+			break
+		}
+
+		if explicit, ok := te.resolveObject(widths.Get(i)).(*parser.Array); ok {
+			for offset := 0; offset < explicit.Len(); offset++ {
+				if width := getNumber(explicit.Get(offset)); width != nil && first+offset >= 0 && first+offset <= 65535 {
+					metrics.widths[uint16(first+offset)] = *width
+				}
+			}
+			i++
+			continue
+		}
+
+		lastObj, ok := widths.Get(i).(*parser.Integer)
+		if !ok || i+1 >= widths.Len() {
+			break
+		}
+		width := getNumber(widths.Get(i + 1))
+		if width == nil {
+			break
+		}
+		last := int(lastObj.Value())
+		for glyphID := first; glyphID <= last && glyphID <= 65535; glyphID++ {
+			if glyphID >= 0 {
+				metrics.widths[uint16(glyphID)] = *width
+			}
+		}
+		i += 2
+	}
+	return metrics
+}
+
+func (te *TextExtractor) resolveObject(object parser.PdfObject) parser.PdfObject {
+	if ref, ok := object.(*parser.IndirectReference); ok {
+		resolved, err := te.reader.GetObject(ref.Number)
+		if err != nil {
+			return nil
+		}
+		return resolved
+	}
+	return object
+}

--- a/internal/extractor/font_metrics.go
+++ b/internal/extractor/font_metrics.go
@@ -71,7 +71,7 @@ func (te *TextExtractor) loadSimpleFontMetrics(fontDict *parser.Dictionary) *fon
 	if !ok {
 		return nil
 	}
-	widthsObj := te.resolveObject(fontDict.Get("Widths"))
+	widthsObj := resolveObject(te.reader, fontDict.Get("Widths"))
 	widthsArray, ok := widthsObj.(*parser.Array)
 	if !ok || widthsArray.Len() == 0 {
 		return nil
@@ -89,7 +89,7 @@ func (te *TextExtractor) loadSimpleFontMetrics(fontDict *parser.Dictionary) *fon
 		}
 	}
 
-	if descriptor, ok := te.resolveObject(fontDict.Get("FontDescriptor")).(*parser.Dictionary); ok {
+	if descriptor, ok := resolveObject(te.reader, fontDict.Get("FontDescriptor")).(*parser.Dictionary); ok {
 		if missingWidth := getNumber(descriptor.Get("MissingWidth")); missingWidth != nil {
 			metrics.defaultWidth = *missingWidth
 		}
@@ -98,11 +98,11 @@ func (te *TextExtractor) loadSimpleFontMetrics(fontDict *parser.Dictionary) *fon
 }
 
 func (te *TextExtractor) loadCompositeFontMetrics(fontDict *parser.Dictionary) *fontMetrics {
-	descendants, ok := te.resolveObject(fontDict.Get("DescendantFonts")).(*parser.Array)
+	descendants, ok := resolveObject(te.reader, fontDict.Get("DescendantFonts")).(*parser.Array)
 	if !ok || descendants.Len() == 0 {
 		return nil
 	}
-	descendant, ok := te.resolveObject(descendants.Get(0)).(*parser.Dictionary)
+	descendant, ok := resolveObject(te.reader, descendants.Get(0)).(*parser.Dictionary)
 	if !ok {
 		return nil
 	}
@@ -115,7 +115,7 @@ func (te *TextExtractor) loadCompositeFontMetrics(fontDict *parser.Dictionary) *
 	if defaultWidth := getNumber(descendant.Get("DW")); defaultWidth != nil {
 		metrics.defaultWidth = *defaultWidth
 	}
-	widths, _ := te.resolveObject(descendant.Get("W")).(*parser.Array)
+	widths, _ := resolveObject(te.reader, descendant.Get("W")).(*parser.Array)
 	if widths == nil {
 		return metrics
 	}
@@ -131,7 +131,7 @@ func (te *TextExtractor) loadCompositeFontMetrics(fontDict *parser.Dictionary) *
 			break
 		}
 
-		if explicit, ok := te.resolveObject(widths.Get(i)).(*parser.Array); ok {
+		if explicit, ok := resolveObject(te.reader, widths.Get(i)).(*parser.Array); ok {
 			for offset := 0; offset < explicit.Len(); offset++ {
 				glyphID := first + int64(offset)
 				if width := getNumber(explicit.Get(offset)); width != nil && glyphID >= 0 && glyphID <= 65535 {
@@ -166,15 +166,4 @@ func (te *TextExtractor) loadCompositeFontMetrics(fontDict *parser.Dictionary) *
 		i += 2
 	}
 	return metrics
-}
-
-func (te *TextExtractor) resolveObject(object parser.PdfObject) parser.PdfObject {
-	if ref, ok := object.(*parser.IndirectReference); ok {
-		resolved, err := te.reader.GetObject(ref.Number)
-		if err != nil {
-			return nil
-		}
-		return resolved
-	}
-	return object
 }

--- a/internal/extractor/font_metrics_test.go
+++ b/internal/extractor/font_metrics_test.go
@@ -8,18 +8,61 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLoadCompositeFontMetricsClampsHostileNegativeRange(t *testing.T) {
-	widths := parser.NewArrayFromSlice([]parser.PdfObject{
-		parser.NewInteger(-2_000_000_000),
-		parser.NewInteger(2),
-		parser.NewInteger(500),
-	})
-	descendant := parser.NewDictionary()
-	descendant.Set("W", widths)
-	font := parser.NewDictionary()
-	font.Set("DescendantFonts", parser.NewArrayFromSlice([]parser.PdfObject{descendant}))
+func TestLoadCompositeFontMetricsBoundsWidthDefinitions(t *testing.T) {
+	tests := []struct {
+		name         string
+		widths       []parser.PdfObject
+		defaultWidth int64
+		want         map[uint16]float64
+	}{
+		{
+			name: "hostile negative range",
+			widths: []parser.PdfObject{
+				parser.NewInteger(-2_000_000_000), parser.NewInteger(2), parser.NewInteger(500),
+			},
+			defaultWidth: 750,
+			want:         map[uint16]float64{0: 500, 1: 500, 2: 500},
+		},
+		{
+			name: "hostile upper range",
+			widths: []parser.PdfObject{
+				parser.NewInteger(65_534), parser.NewInteger(2_000_000_000), parser.NewInteger(600),
+			},
+			defaultWidth: 800,
+			want:         map[uint16]float64{65_534: 600, 65_535: 600},
+		},
+		{
+			name: "range outside cid space",
+			widths: []parser.PdfObject{
+				parser.NewInteger(-20), parser.NewInteger(-10), parser.NewInteger(400),
+			},
+			defaultWidth: 900,
+			want:         map[uint16]float64{},
+		},
+		{
+			name: "explicit widths crossing zero",
+			widths: []parser.PdfObject{
+				parser.NewInteger(-1), parser.NewArrayFromSlice([]parser.PdfObject{
+					parser.NewInteger(100), parser.NewInteger(200), parser.NewInteger(300),
+				}),
+			},
+			defaultWidth: 1_000,
+			want:         map[uint16]float64{0: 200, 1: 300},
+		},
+	}
 
-	metrics := (&TextExtractor{}).loadCompositeFontMetrics(font)
-	require.NotNil(t, metrics)
-	assert.Equal(t, map[uint16]float64{0: 500, 1: 500, 2: 500}, metrics.widths)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			descendant := parser.NewDictionary()
+			descendant.Set("DW", parser.NewInteger(test.defaultWidth))
+			descendant.Set("W", parser.NewArrayFromSlice(test.widths))
+			font := parser.NewDictionary()
+			font.Set("DescendantFonts", parser.NewArrayFromSlice([]parser.PdfObject{descendant}))
+
+			metrics := (&TextExtractor{}).loadCompositeFontMetrics(font)
+			require.NotNil(t, metrics)
+			assert.Equal(t, float64(test.defaultWidth), metrics.defaultWidth)
+			assert.Equal(t, test.want, metrics.widths)
+		})
+	}
 }

--- a/internal/extractor/font_metrics_test.go
+++ b/internal/extractor/font_metrics_test.go
@@ -1,0 +1,25 @@
+package extractor
+
+import (
+	"testing"
+
+	"github.com/coregx/gxpdf/internal/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadCompositeFontMetricsClampsHostileNegativeRange(t *testing.T) {
+	widths := parser.NewArrayFromSlice([]parser.PdfObject{
+		parser.NewInteger(-2_000_000_000),
+		parser.NewInteger(2),
+		parser.NewInteger(500),
+	})
+	descendant := parser.NewDictionary()
+	descendant.Set("W", widths)
+	font := parser.NewDictionary()
+	font.Set("DescendantFonts", parser.NewArrayFromSlice([]parser.PdfObject{descendant}))
+
+	metrics := (&TextExtractor{}).loadCompositeFontMetrics(font)
+	require.NotNil(t, metrics)
+	assert.Equal(t, map[uint16]float64{0: 500, 1: 500, 2: 500}, metrics.widths)
+}

--- a/internal/extractor/form_xobject_test.go
+++ b/internal/extractor/form_xobject_test.go
@@ -421,6 +421,7 @@ func TestFormXObject_AppliesPageAndFormTransformsToGlyphGeometry(t *testing.T) {
 	assert.InDelta(t, 6, elements[0].Width, 0.001)
 	assert.InDelta(t, 5, elements[0].Height, 0.001)
 	assert.InDelta(t, 5, elements[0].FontSize, 0.001)
+	assert.True(t, elements[0].preciseWidth)
 
 	assert.Equal(t, "C", elements[1].Text)
 	assert.InDelta(t, 67.5, elements[1].X, 0.001)
@@ -432,6 +433,7 @@ func TestFormXObject_AppliesPageAndFormTransformsToGlyphGeometry(t *testing.T) {
 	assert.InDelta(t, 20, elements[2].Y, 0.001)
 	assert.InDelta(t, 6, elements[2].Width, 0.001)
 	assert.InDelta(t, 10, elements[2].FontSize, 0.001)
+	assert.False(t, elements[2].preciseWidth, "direct-page text must retain legacy width behavior")
 
 	assert.Equal(t, "AB C\nD", AssembleText(elements))
 }

--- a/internal/extractor/form_xobject_test.go
+++ b/internal/extractor/form_xobject_test.go
@@ -244,6 +244,39 @@ func buildNestedXObjectPDF(t *testing.T) []byte {
 	return b.finalize(catalogN)
 }
 
+// buildTransformedGlyphXObjectPDF mimics Quartz-generated financial reports:
+// the page scales a Form XObject, the Form supplies its own matrix, and each
+// glyph is positioned by a nested cm operator while the text matrix stays at
+// the origin. Accurate coordinates therefore require all three transforms.
+func buildTransformedGlyphXObjectPDF(t *testing.T) []byte {
+	t.Helper()
+
+	b := newXObjPDFBuilder(20)
+	fontN := b.addRaw("<< /Type /Font /Subtype /TrueType /BaseFont /Test /FirstChar 65 /LastChar 68 /Widths [600 600 600 600] >>")
+
+	xobjContent := []byte(strings.Join([]string{
+		"q 10 0 0 10 100 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (A) Tj ET Q",
+		"q 10 0 0 10 106 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (B) Tj ET Q",
+		"q 10 0 0 10 115 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (C) Tj ET Q",
+	}, "\n"))
+	xobjN := b.addStream(
+		fmt.Sprintf("/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Matrix [1 0 0 1 20 30] /Resources << /Font << /F1 %d 0 R >> >>", fontN),
+		xobjContent,
+	)
+
+	// The direct page text after Q proves that the Form and graphics state are
+	// restored rather than leaking their scale/translation into the caller.
+	pageContent := []byte("q 0.5 0 0 0.5 0 0 cm /Fm1 Do Q BT /F1 10 Tf 1 0 0 1 10 20 Tm (D) Tj ET")
+	pageContentN := b.addStream("", pageContent)
+	pageN := b.addRaw(fmt.Sprintf(
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 %d 0 R >> /XObject << /Fm1 %d 0 R >> >> /Contents %d 0 R >>",
+		fontN, xobjN, pageContentN,
+	))
+	pagesN := b.addRaw(fmt.Sprintf("<< /Type /Pages /Kids [%d 0 R] /Count 1 >>", pageN))
+	catalogN := b.addRaw(fmt.Sprintf("<< /Type /Catalog /Pages %d 0 R >>", pagesN))
+	return b.finalize(catalogN)
+}
+
 // buildImageXObjectPDF builds a PDF whose XObjects section contains only an
 // Image XObject (Subtype /Image). The extractor must skip it silently.
 //
@@ -372,6 +405,35 @@ func TestFormXObject_SimpleFont_ExtractsText(t *testing.T) {
 	}
 	assert.Equal(t, "Hello World", sb.String(),
 		"Form XObject with simple font must produce correct text")
+}
+
+func TestFormXObject_AppliesPageAndFormTransformsToGlyphGeometry(t *testing.T) {
+	reader := openPDFBytes(t, buildTransformedGlyphXObjectPDF(t))
+	extractor := NewTextExtractor(reader)
+
+	elements, err := extractor.ExtractFromPage(0)
+	require.NoError(t, err)
+	require.Len(t, elements, 3)
+
+	assert.Equal(t, "AB", elements[0].Text)
+	assert.InDelta(t, 60, elements[0].X, 0.001)
+	assert.InDelta(t, 115, elements[0].Y, 0.001)
+	assert.InDelta(t, 6, elements[0].Width, 0.001)
+	assert.InDelta(t, 5, elements[0].Height, 0.001)
+	assert.InDelta(t, 5, elements[0].FontSize, 0.001)
+
+	assert.Equal(t, "C", elements[1].Text)
+	assert.InDelta(t, 67.5, elements[1].X, 0.001)
+	assert.InDelta(t, 115, elements[1].Y, 0.001)
+	assert.InDelta(t, 3, elements[1].Width, 0.001)
+
+	assert.Equal(t, "D", elements[2].Text)
+	assert.InDelta(t, 10, elements[2].X, 0.001)
+	assert.InDelta(t, 20, elements[2].Y, 0.001)
+	assert.InDelta(t, 6, elements[2].Width, 0.001)
+	assert.InDelta(t, 10, elements[2].FontSize, 0.001)
+
+	assert.Equal(t, "AB C\nD", AssembleText(elements))
 }
 
 // ─── Test 2: Type0 CID font inside Form XObject (TCPDF pattern) ──────────────

--- a/internal/extractor/form_xobject_test.go
+++ b/internal/extractor/form_xobject_test.go
@@ -134,6 +134,27 @@ func buildSimpleFontXObjectPDF(t *testing.T) []byte {
 	return b.finalize(catalogN)
 }
 
+// buildUnbalancedRestoreXObjectPDF places an unmatched Q at the start of a
+// Form. PDF Form execution has its own graphics-state stack, so that malformed
+// operator must not consume the page's surrounding q or change later geometry.
+func buildUnbalancedRestoreXObjectPDF(t *testing.T) []byte {
+	t.Helper()
+	b := newXObjPDFBuilder(15)
+	fontN := b.addRaw("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>")
+	xobjN := b.addStream(
+		fmt.Sprintf("/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Resources << /Font << /F1 %d 0 R >> >>", fontN),
+		[]byte("Q BT /F1 1 Tf 0 0 Td (A) Tj ET"),
+	)
+	pageContentN := b.addStream("", []byte("q 2 0 0 2 10 20 cm /TPL1 Do Q BT /F1 10 Tf 10 20 Td (D) Tj ET"))
+	pageN := b.addRaw(fmt.Sprintf(
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 %d 0 R >> /XObject << /TPL1 %d 0 R >> >> /Contents %d 0 R >>",
+		fontN, xobjN, pageContentN,
+	))
+	pagesN := b.addRaw(fmt.Sprintf("<< /Type /Pages /Kids [%d 0 R] /Count 1 >>", pageN))
+	catalogN := b.addRaw(fmt.Sprintf("<< /Type /Catalog /Pages %d 0 R >>", pagesN))
+	return b.finalize(catalogN)
+}
+
 // buildType0XObjectPDF constructs a PDF that mimics the TCPDF Correo Argentino
 // pattern: all text is inside a Form XObject, and the font is Type0 with
 // Identity-H encoding + a ToUnicode CMap using bfrange scalar form.
@@ -436,6 +457,22 @@ func TestFormXObject_AppliesPageAndFormTransformsToGlyphGeometry(t *testing.T) {
 	assert.False(t, elements[2].preciseWidth, "direct-page text must retain legacy width behavior")
 
 	assert.Equal(t, "AB C\nD", AssembleText(elements))
+}
+
+func TestFormXObject_UnmatchedRestoreCannotPopCallerGraphicsState(t *testing.T) {
+	reader := openPDFBytes(t, buildUnbalancedRestoreXObjectPDF(t))
+	extractor := NewTextExtractor(reader)
+
+	elements, err := extractor.ExtractFromPage(0)
+	require.NoError(t, err)
+	require.Len(t, elements, 2)
+
+	assert.Equal(t, "A", elements[0].Text)
+	assert.InDelta(t, 10, elements[0].X, 0.001)
+	assert.InDelta(t, 20, elements[0].Y, 0.001)
+	assert.Equal(t, "D", elements[1].Text)
+	assert.InDelta(t, 10, elements[1].X, 0.001)
+	assert.InDelta(t, 20, elements[1].Y, 0.001)
 }
 
 // ─── Test 2: Type0 CID font inside Form XObject (TCPDF pattern) ──────────────

--- a/internal/extractor/form_xobject_test.go
+++ b/internal/extractor/form_xobject_test.go
@@ -270,6 +270,10 @@ func buildNestedXObjectPDF(t *testing.T) []byte {
 // glyph is positioned by a nested cm operator while the text matrix stays at
 // the origin. Accurate coordinates therefore require all three transforms.
 func buildTransformedGlyphXObjectPDF(t *testing.T) []byte {
+	return buildTransformedGlyphXObjectPDFWithRotation(t, 0)
+}
+
+func buildTransformedGlyphXObjectPDFWithRotation(t *testing.T, rotation int) []byte {
 	t.Helper()
 
 	b := newXObjPDFBuilder(20)
@@ -289,9 +293,13 @@ func buildTransformedGlyphXObjectPDF(t *testing.T) []byte {
 	// restored rather than leaking their scale/translation into the caller.
 	pageContent := []byte("q 0.5 0 0 0.5 0 0 cm /Fm1 Do Q BT /F1 10 Tf 1 0 0 1 10 20 Tm (D) Tj ET")
 	pageContentN := b.addStream("", pageContent)
+	rotationEntry := ""
+	if rotation != 0 {
+		rotationEntry = fmt.Sprintf(" /Rotate %d", rotation)
+	}
 	pageN := b.addRaw(fmt.Sprintf(
-		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 %d 0 R >> /XObject << /Fm1 %d 0 R >> >> /Contents %d 0 R >>",
-		fontN, xobjN, pageContentN,
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]%s /Resources << /Font << /F1 %d 0 R >> /XObject << /Fm1 %d 0 R >> >> /Contents %d 0 R >>",
+		rotationEntry, fontN, xobjN, pageContentN,
 	))
 	pagesN := b.addRaw(fmt.Sprintf("<< /Type /Pages /Kids [%d 0 R] /Count 1 >>", pageN))
 	catalogN := b.addRaw(fmt.Sprintf("<< /Type /Catalog /Pages %d 0 R >>", pagesN))
@@ -429,34 +437,40 @@ func TestFormXObject_SimpleFont_ExtractsText(t *testing.T) {
 }
 
 func TestFormXObject_AppliesPageAndFormTransformsToGlyphGeometry(t *testing.T) {
-	reader := openPDFBytes(t, buildTransformedGlyphXObjectPDF(t))
-	extractor := NewTextExtractor(reader)
+	for _, rotation := range []int{0, 90} {
+		t.Run(fmt.Sprintf("page-rotate-%d", rotation), func(t *testing.T) {
+			reader := openPDFBytes(t, buildTransformedGlyphXObjectPDFWithRotation(t, rotation))
+			extractor := NewTextExtractor(reader)
 
-	elements, err := extractor.ExtractFromPage(0)
-	require.NoError(t, err)
-	require.Len(t, elements, 3)
+			elements, err := extractor.ExtractFromPage(0)
+			require.NoError(t, err)
+			require.Len(t, elements, 3)
 
-	assert.Equal(t, "AB", elements[0].Text)
-	assert.InDelta(t, 60, elements[0].X, 0.001)
-	assert.InDelta(t, 115, elements[0].Y, 0.001)
-	assert.InDelta(t, 6, elements[0].Width, 0.001)
-	assert.InDelta(t, 5, elements[0].Height, 0.001)
-	assert.InDelta(t, 5, elements[0].FontSize, 0.001)
-	assert.True(t, elements[0].preciseWidth)
+			// /Rotate controls page display orientation. Extracted coordinates stay
+			// in PDF page user space and must not disturb Form matrix composition.
+			assert.Equal(t, "AB", elements[0].Text)
+			assert.InDelta(t, 60, elements[0].X, 0.001)
+			assert.InDelta(t, 115, elements[0].Y, 0.001)
+			assert.InDelta(t, 6, elements[0].Width, 0.001)
+			assert.InDelta(t, 5, elements[0].Height, 0.001)
+			assert.InDelta(t, 5, elements[0].FontSize, 0.001)
+			assert.True(t, elements[0].preciseWidth)
 
-	assert.Equal(t, "C", elements[1].Text)
-	assert.InDelta(t, 67.5, elements[1].X, 0.001)
-	assert.InDelta(t, 115, elements[1].Y, 0.001)
-	assert.InDelta(t, 3, elements[1].Width, 0.001)
+			assert.Equal(t, "C", elements[1].Text)
+			assert.InDelta(t, 67.5, elements[1].X, 0.001)
+			assert.InDelta(t, 115, elements[1].Y, 0.001)
+			assert.InDelta(t, 3, elements[1].Width, 0.001)
 
-	assert.Equal(t, "D", elements[2].Text)
-	assert.InDelta(t, 10, elements[2].X, 0.001)
-	assert.InDelta(t, 20, elements[2].Y, 0.001)
-	assert.InDelta(t, 6, elements[2].Width, 0.001)
-	assert.InDelta(t, 10, elements[2].FontSize, 0.001)
-	assert.False(t, elements[2].preciseWidth, "direct-page text must retain legacy width behavior")
+			assert.Equal(t, "D", elements[2].Text)
+			assert.InDelta(t, 10, elements[2].X, 0.001)
+			assert.InDelta(t, 20, elements[2].Y, 0.001)
+			assert.InDelta(t, 6, elements[2].Width, 0.001)
+			assert.InDelta(t, 10, elements[2].FontSize, 0.001)
+			assert.False(t, elements[2].preciseWidth, "direct-page text must retain legacy width behavior")
 
-	assert.Equal(t, "AB C\nD", AssembleText(elements))
+			assert.Equal(t, "AB C\nD", AssembleText(elements))
+		})
+	}
 }
 
 func TestFormXObject_UnmatchedRestoreCannotPopCallerGraphicsState(t *testing.T) {

--- a/internal/extractor/form_xobject_test.go
+++ b/internal/extractor/form_xobject_test.go
@@ -309,6 +309,54 @@ func positionedText(text, operator string) string {
 	return fmt.Sprintf("(%s) Tj", text)
 }
 
+// buildResourceScopedFontsXObjectPDF creates two sibling Forms that both call
+// their font /F1 while defining different encodings and widths for that local
+// name. Decoder and metric caches must not cross the resource boundary.
+func buildResourceScopedFontsXObjectPDF(t *testing.T) []byte {
+	t.Helper()
+	b := newXObjPDFBuilder(20)
+	firstFontN := b.addRaw("<< /Type /Font /Subtype /TrueType /BaseFont /First /FirstChar 65 /LastChar 65 /Widths [600] /Encoding /WinAnsiEncoding >>")
+	secondFontN := b.addRaw("<< /Type /Font /Subtype /TrueType /BaseFont /Second /FirstChar 65 /LastChar 65 /Widths [1000] /Encoding << /BaseEncoding /WinAnsiEncoding /Differences [65 /Z] >> >>")
+	firstFormN := b.addStream(
+		fmt.Sprintf("/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Resources << /Font << /F1 %d 0 R >> >>", firstFontN),
+		[]byte("q 10 0 0 10 0 100 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (A) Tj ET Q"),
+	)
+	secondFormN := b.addStream(
+		fmt.Sprintf("/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Resources << /Font << /F1 %d 0 R >> >>", secondFontN),
+		[]byte("q 10 0 0 10 20 100 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (A) Tj ET Q"),
+	)
+	pageContentN := b.addStream("", []byte("/First Do /Second Do"))
+	pageN := b.addRaw(fmt.Sprintf(
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /First %d 0 R /Second %d 0 R >> >> /Contents %d 0 R >>",
+		firstFormN, secondFormN, pageContentN,
+	))
+	pagesN := b.addRaw(fmt.Sprintf("<< /Type /Pages /Kids [%d 0 R] /Count 1 >>", pageN))
+	catalogN := b.addRaw(fmt.Sprintf("<< /Type /Catalog /Pages %d 0 R >>", pagesN))
+	return b.finalize(catalogN)
+}
+
+// buildFormTextStateIsolationPDF changes every tracked text-state parameter in
+// a Form, then emits caller text without setting those parameters again.
+func buildFormTextStateIsolationPDF(t *testing.T) []byte {
+	t.Helper()
+	b := newXObjPDFBuilder(20)
+	pageFontN := b.addRaw("<< /Type /Font /Subtype /TrueType /BaseFont /Page /FirstChar 68 /LastChar 68 /Widths [600] >>")
+	formFontN := b.addRaw("<< /Type /Font /Subtype /TrueType /BaseFont /Form /FirstChar 65 /LastChar 65 /Widths [600] >>")
+	formN := b.addStream(
+		fmt.Sprintf("/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Resources << /Font << /FForm %d 0 R >> >>", formFontN),
+		[]byte("BT /FForm 1 Tf 9 Tc 8 Tw 50 Tz 7 TL 3 Ts 1 0 0 1 0 100 Tm (A) Tj ET"),
+	)
+	pageContent := []byte("BT /FPage 10 Tf 1 Tc 2 Tw 80 Tz 14 TL 4 Ts ET /Fm Do BT 1 0 0 1 20 20 Tm (D) Tj ET")
+	pageContentN := b.addStream("", pageContent)
+	pageN := b.addRaw(fmt.Sprintf(
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /FPage %d 0 R >> /XObject << /Fm %d 0 R >> >> /Contents %d 0 R >>",
+		pageFontN, formN, pageContentN,
+	))
+	pagesN := b.addRaw(fmt.Sprintf("<< /Type /Pages /Kids [%d 0 R] /Count 1 >>", pageN))
+	catalogN := b.addRaw(fmt.Sprintf("<< /Type /Catalog /Pages %d 0 R >>", pagesN))
+	return b.finalize(catalogN)
+}
+
 // buildImageXObjectPDF builds a PDF whose XObjects section contains only an
 // Image XObject (Subtype /Image). The extractor must skip it silently.
 //
@@ -476,6 +524,92 @@ func TestFormXObject_AppliesPageAndFormTransformsToGlyphGeometry(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestFormXObject_FontCachesAreScopedToResources(t *testing.T) {
+	reader := openPDFBytes(t, buildResourceScopedFontsXObjectPDF(t))
+	extractor := NewTextExtractor(reader)
+
+	elements, err := extractor.ExtractFromPage(0)
+	require.NoError(t, err)
+	require.Len(t, elements, 2)
+
+	assert.Equal(t, "A", elements[0].Text)
+	assert.InDelta(t, 6, elements[0].Width, 0.001)
+	assert.Equal(t, "Z", elements[1].Text)
+	assert.InDelta(t, 10, elements[1].Width, 0.001)
+}
+
+func TestFormXObject_RestoresCallerTextState(t *testing.T) {
+	reader := openPDFBytes(t, buildFormTextStateIsolationPDF(t))
+	extractor := NewTextExtractor(reader)
+
+	elements, err := extractor.ExtractFromPage(0)
+	require.NoError(t, err)
+	require.Len(t, elements, 2)
+
+	assert.Equal(t, "D", elements[1].Text)
+	assert.Equal(t, "FPage", elements[1].FontName)
+	assert.InDelta(t, 10, elements[1].FontSize, 0.001)
+	assert.InDelta(t, 4.8, elements[1].Width, 0.001)
+	assert.Equal(t, "FPage", extractor.textState.FontName)
+	assert.InDelta(t, 10, extractor.textState.FontSize, 0.001)
+	assert.InDelta(t, 1, extractor.textState.CharSpace, 0.001)
+	assert.InDelta(t, 2, extractor.textState.WordSpace, 0.001)
+	assert.InDelta(t, 80, extractor.textState.HorizScale, 0.001)
+	assert.InDelta(t, 14, extractor.textState.Leading, 0.001)
+	assert.InDelta(t, 4, extractor.textState.Rise, 0.001)
+}
+
+func TestGraphicsStateRestoresTextParametersButNotTextMatrix(t *testing.T) {
+	extractor := NewTextExtractor(nil)
+	extractor.textState.SetFont("CallerFont", 12)
+	extractor.textState.CharSpace = 1
+	extractor.textState.WordSpace = 2
+	extractor.textState.HorizScale = 80
+	extractor.textState.Leading = 14
+	extractor.textState.Rise = 4
+	extractor.processOperator(&Operator{Name: "q"})
+
+	extractor.textState.SetFont("NestedFont", 1)
+	extractor.textState.CharSpace = 9
+	extractor.textState.WordSpace = 8
+	extractor.textState.HorizScale = 50
+	extractor.textState.Leading = 7
+	extractor.textState.Rise = 3
+	extractor.textState.SetTextMatrix(1, 0, 0, 1, 30, 40)
+	extractor.processOperator(&Operator{Name: "Q"})
+
+	assert.Equal(t, "CallerFont", extractor.textState.FontName)
+	assert.InDelta(t, 12, extractor.textState.FontSize, 0.001)
+	assert.InDelta(t, 1, extractor.textState.CharSpace, 0.001)
+	assert.InDelta(t, 2, extractor.textState.WordSpace, 0.001)
+	assert.InDelta(t, 80, extractor.textState.HorizScale, 0.001)
+	assert.InDelta(t, 14, extractor.textState.Leading, 0.001)
+	assert.InDelta(t, 4, extractor.textState.Rise, 0.001)
+	assert.InDelta(t, 30, extractor.textState.CurrentX, 0.001, "q/Q must not restore the text matrix")
+	assert.InDelta(t, 40, extractor.textState.CurrentY, 0.001, "q/Q must not restore the text matrix")
+}
+
+func TestPositionedTJAdjustmentHonorsHorizontalScaling(t *testing.T) {
+	extractor := NewTextExtractor(nil)
+	extractor.xobjectDepth = 1
+	extractor.ctm = Scaling(10, 10)
+	extractor.textState.SetFont("F1", 1)
+	extractor.textState.HorizScale = 50
+	extractor.fontMetrics["F1"] = &fontMetrics{
+		widths:       map[uint16]float64{65: 600, 66: 600},
+		defaultWidth: 600,
+		precise:      true,
+	}
+	items := parser.NewArrayFromSlice([]parser.PdfObject{
+		parser.NewString("A"), parser.NewInteger(-100), parser.NewString("B"),
+	})
+
+	extractor.processTextArray(items)
+	require.Len(t, extractor.elements, 2)
+	assert.InDelta(t, 0, extractor.elements[0].X, 0.001)
+	assert.InDelta(t, 3.5, extractor.elements[1].X, 0.001)
 }
 
 func TestFormXObject_UnmatchedRestoreCannotPopCallerGraphicsState(t *testing.T) {

--- a/internal/extractor/form_xobject_test.go
+++ b/internal/extractor/form_xobject_test.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"compress/zlib"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -239,19 +240,19 @@ func buildNestedXObjectPDF(t *testing.T) []byte {
 
 	// L2 Form XObject: actual text in its stream body
 	l2N := b.addStream(
-		fmt.Sprintf("/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Resources << /Font << /F1 %d 0 R >> >>", fontN),
+		fmt.Sprintf("/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Matrix [1 0 0 1 40 50] /Resources << /Font << /F1 %d 0 R >> >>", fontN),
 		[]byte("BT /F1 12 Tf 10 700 Td (Nested) Tj ET"),
 	)
 
 	// L1 Form XObject: invokes L2 from its stream body
 	l1N := b.addStream(
-		fmt.Sprintf("/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Resources << /XObject << /L2 %d 0 R >> /Font << /F1 %d 0 R >> >>",
+		fmt.Sprintf("/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Matrix [1 0 0 1 20 30] /Resources << /XObject << /L2 %d 0 R >> /Font << /F1 %d 0 R >> >>",
 			l2N, fontN),
 		[]byte("/L2 Do"),
 	)
 
 	// Page content: invoke L1
-	pageContentN := b.addStream("", []byte("/L1 Do"))
+	pageContentN := b.addStream("", []byte("q 1 0 0 1 5 7 cm /L1 Do Q"))
 
 	// Page
 	pageN := b.addRaw(fmt.Sprintf(
@@ -665,6 +666,44 @@ func TestFormXObject_Nested_ExtractsText(t *testing.T) {
 	}
 	assert.Equal(t, "Nested", sb.String(),
 		"text from doubly-nested Form XObject must be extracted")
+	assert.InDelta(t, 75, elements[0].X, 0.001)
+	assert.InDelta(t, 787, elements[0].Y, 0.001)
+}
+
+func TestFormTextGeometryHandlesAffineTransforms(t *testing.T) {
+	tests := []struct {
+		name                       string
+		ctm                        Matrix
+		fontSize, horizontal, rise float64
+		wantX, wantY, wantW, wantH float64
+		wantEffectiveFontSize      float64
+	}{
+		{name: "rotation", ctm: Rotation(math.Pi / 2), fontSize: 10, horizontal: 100, wantX: -30, wantY: 10, wantW: 10, wantH: 6, wantEffectiveFontSize: 10},
+		{name: "skew", ctm: NewMatrix(1, 0.5, 0.25, 1, 3, 4), fontSize: 10, horizontal: 100, wantX: 18, wantY: 29, wantW: 8.5, wantH: 13, wantEffectiveFontSize: math.Hypot(2.5, 10)},
+		{name: "reflection", ctm: NewMatrix(-1, 0, 0, 1, 100, 0), fontSize: 10, horizontal: 100, wantX: 84, wantY: 20, wantW: 6, wantH: 10, wantEffectiveFontSize: 10},
+		{name: "non-uniform scale with rise and horizontal scaling", ctm: NewMatrix(2, 0, 0, 3, 5, 7), fontSize: 10, horizontal: 50, rise: 2, wantX: 25, wantY: 73, wantW: 6, wantH: 30, wantEffectiveFontSize: 30},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			extractor := NewTextExtractor(nil)
+			extractor.xobjectDepth = 1
+			extractor.ctm = test.ctm
+			extractor.textState.SetFont("F1", test.fontSize)
+			extractor.textState.SetTextMatrix(1, 0, 0, 1, 10, 20)
+			extractor.textState.HorizScale = test.horizontal
+			extractor.textState.Rise = test.rise
+			extractor.fontMetrics["F1"] = &fontMetrics{widths: map[uint16]float64{65: 600}, defaultWidth: 600, precise: true}
+			extractor.addTextBytes([]byte("A"))
+			require.Len(t, extractor.elements, 1)
+			element := extractor.elements[0]
+			assert.InDelta(t, test.wantX, element.X, 0.001)
+			assert.InDelta(t, test.wantY, element.Y, 0.001)
+			assert.InDelta(t, test.wantW, element.Width, 0.001)
+			assert.InDelta(t, test.wantH, element.Height, 0.001)
+			assert.InDelta(t, test.wantEffectiveFontSize, element.FontSize, 0.001)
+		})
+	}
 }
 
 // ─── Test 4: Image XObject — must be silently skipped ────────────────────────

--- a/internal/extractor/form_xobject_test.go
+++ b/internal/extractor/form_xobject_test.go
@@ -303,6 +303,29 @@ func buildTransformedGlyphXObjectPDF(t *testing.T, rotation int, textOperator st
 	return b.finalize(catalogN)
 }
 
+// buildRepeatedFormXObjectPDF invokes the same Form twice under different page
+// transforms. Reusing the cached Form must compose with each caller independently.
+func buildRepeatedFormXObjectPDF(t *testing.T) []byte {
+	t.Helper()
+	b := newXObjPDFBuilder(15)
+	fontN := b.addRaw("<< /Type /Font /Subtype /TrueType /BaseFont /Test /FirstChar 65 /LastChar 65 /Widths [600] >>")
+	formN := b.addStream(
+		fmt.Sprintf("/Type /XObject /Subtype /Form /BBox [0 0 100 100] /Resources << /Font << /F1 %d 0 R >> >>", fontN),
+		[]byte("BT /F1 10 Tf 1 0 0 1 0 0 Tm (A) Tj ET"),
+	)
+	pageContentN := b.addStream("", []byte(strings.Join([]string{
+		"q 1 0 0 1 10 20 cm /Fm Do Q",
+		"q 2 0 0 3 100 200 cm /Fm Do Q",
+	}, "\n")))
+	pageN := b.addRaw(fmt.Sprintf(
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /Fm %d 0 R >> >> /Contents %d 0 R >>",
+		formN, pageContentN,
+	))
+	pagesN := b.addRaw(fmt.Sprintf("<< /Type /Pages /Kids [%d 0 R] /Count 1 >>", pageN))
+	catalogN := b.addRaw(fmt.Sprintf("<< /Type /Catalog /Pages %d 0 R >>", pagesN))
+	return b.finalize(catalogN)
+}
+
 func positionedText(text, operator string) string {
 	if operator == "TJ" {
 		return fmt.Sprintf("[(%s)] TJ", text)
@@ -490,7 +513,7 @@ func TestFormXObject_SimpleFont_ExtractsText(t *testing.T) {
 
 func TestFormXObject_AppliesPageAndFormTransformsToGlyphGeometry(t *testing.T) {
 	for _, textOperator := range []string{"Tj", "TJ"} {
-		for _, rotation := range []int{0, 90} {
+		for _, rotation := range []int{0, 90, 180, 270} {
 			t.Run(fmt.Sprintf("%s/page-rotate-%d", textOperator, rotation), func(t *testing.T) {
 				reader := openPDFBytes(t, buildTransformedGlyphXObjectPDF(t, rotation, textOperator))
 				extractor := NewTextExtractor(reader)
@@ -525,6 +548,27 @@ func TestFormXObject_AppliesPageAndFormTransformsToGlyphGeometry(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestFormXObject_RepeatedInvocationUsesEachCallerTransform(t *testing.T) {
+	reader := openPDFBytes(t, buildRepeatedFormXObjectPDF(t))
+	extractor := NewTextExtractor(reader)
+
+	elements, err := extractor.ExtractFromPage(0)
+	require.NoError(t, err)
+	require.Len(t, elements, 2)
+
+	assert.Equal(t, "A", elements[0].Text)
+	assert.InDelta(t, 10, elements[0].X, 0.001)
+	assert.InDelta(t, 20, elements[0].Y, 0.001)
+	assert.InDelta(t, 6, elements[0].Width, 0.001)
+	assert.InDelta(t, 10, elements[0].Height, 0.001)
+
+	assert.Equal(t, "A", elements[1].Text)
+	assert.InDelta(t, 100, elements[1].X, 0.001)
+	assert.InDelta(t, 200, elements[1].Y, 0.001)
+	assert.InDelta(t, 12, elements[1].Width, 0.001)
+	assert.InDelta(t, 30, elements[1].Height, 0.001)
 }
 
 func TestFormXObject_FontCachesAreScopedToResources(t *testing.T) {

--- a/internal/extractor/form_xobject_test.go
+++ b/internal/extractor/form_xobject_test.go
@@ -269,20 +269,16 @@ func buildNestedXObjectPDF(t *testing.T) []byte {
 // the page scales a Form XObject, the Form supplies its own matrix, and each
 // glyph is positioned by a nested cm operator while the text matrix stays at
 // the origin. Accurate coordinates therefore require all three transforms.
-func buildTransformedGlyphXObjectPDF(t *testing.T) []byte {
-	return buildTransformedGlyphXObjectPDFWithRotation(t, 0)
-}
-
-func buildTransformedGlyphXObjectPDFWithRotation(t *testing.T, rotation int) []byte {
+func buildTransformedGlyphXObjectPDF(t *testing.T, rotation int, textOperator string) []byte {
 	t.Helper()
 
 	b := newXObjPDFBuilder(20)
 	fontN := b.addRaw("<< /Type /Font /Subtype /TrueType /BaseFont /Test /FirstChar 65 /LastChar 68 /Widths [600 600 600 600] >>")
 
 	xobjContent := []byte(strings.Join([]string{
-		"q 10 0 0 10 100 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (A) Tj ET Q",
-		"q 10 0 0 10 106 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (B) Tj ET Q",
-		"q 10 0 0 10 115 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (C) Tj ET Q",
+		fmt.Sprintf("q 10 0 0 10 100 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm %s ET Q", positionedText("A", textOperator)),
+		fmt.Sprintf("q 10 0 0 10 106 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm %s ET Q", positionedText("B", textOperator)),
+		fmt.Sprintf("q 10 0 0 10 115 200 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm %s ET Q", positionedText("C", textOperator)),
 	}, "\n"))
 	xobjN := b.addStream(
 		fmt.Sprintf("/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Matrix [1 0 0 1 20 30] /Resources << /Font << /F1 %d 0 R >> >>", fontN),
@@ -304,6 +300,13 @@ func buildTransformedGlyphXObjectPDFWithRotation(t *testing.T, rotation int) []b
 	pagesN := b.addRaw(fmt.Sprintf("<< /Type /Pages /Kids [%d 0 R] /Count 1 >>", pageN))
 	catalogN := b.addRaw(fmt.Sprintf("<< /Type /Catalog /Pages %d 0 R >>", pagesN))
 	return b.finalize(catalogN)
+}
+
+func positionedText(text, operator string) string {
+	if operator == "TJ" {
+		return fmt.Sprintf("[(%s)] TJ", text)
+	}
+	return fmt.Sprintf("(%s) Tj", text)
 }
 
 // buildImageXObjectPDF builds a PDF whose XObjects section contains only an
@@ -437,39 +440,41 @@ func TestFormXObject_SimpleFont_ExtractsText(t *testing.T) {
 }
 
 func TestFormXObject_AppliesPageAndFormTransformsToGlyphGeometry(t *testing.T) {
-	for _, rotation := range []int{0, 90} {
-		t.Run(fmt.Sprintf("page-rotate-%d", rotation), func(t *testing.T) {
-			reader := openPDFBytes(t, buildTransformedGlyphXObjectPDFWithRotation(t, rotation))
-			extractor := NewTextExtractor(reader)
+	for _, textOperator := range []string{"Tj", "TJ"} {
+		for _, rotation := range []int{0, 90} {
+			t.Run(fmt.Sprintf("%s/page-rotate-%d", textOperator, rotation), func(t *testing.T) {
+				reader := openPDFBytes(t, buildTransformedGlyphXObjectPDF(t, rotation, textOperator))
+				extractor := NewTextExtractor(reader)
 
-			elements, err := extractor.ExtractFromPage(0)
-			require.NoError(t, err)
-			require.Len(t, elements, 3)
+				elements, err := extractor.ExtractFromPage(0)
+				require.NoError(t, err)
+				require.Len(t, elements, 3)
 
-			// /Rotate controls page display orientation. Extracted coordinates stay
-			// in PDF page user space and must not disturb Form matrix composition.
-			assert.Equal(t, "AB", elements[0].Text)
-			assert.InDelta(t, 60, elements[0].X, 0.001)
-			assert.InDelta(t, 115, elements[0].Y, 0.001)
-			assert.InDelta(t, 6, elements[0].Width, 0.001)
-			assert.InDelta(t, 5, elements[0].Height, 0.001)
-			assert.InDelta(t, 5, elements[0].FontSize, 0.001)
-			assert.True(t, elements[0].preciseWidth)
+				// /Rotate controls page display orientation. Extracted coordinates stay
+				// in PDF page user space and must not disturb Form matrix composition.
+				assert.Equal(t, "AB", elements[0].Text)
+				assert.InDelta(t, 60, elements[0].X, 0.001)
+				assert.InDelta(t, 115, elements[0].Y, 0.001)
+				assert.InDelta(t, 6, elements[0].Width, 0.001)
+				assert.InDelta(t, 5, elements[0].Height, 0.001)
+				assert.InDelta(t, 5, elements[0].FontSize, 0.001)
+				assert.True(t, elements[0].preciseWidth)
 
-			assert.Equal(t, "C", elements[1].Text)
-			assert.InDelta(t, 67.5, elements[1].X, 0.001)
-			assert.InDelta(t, 115, elements[1].Y, 0.001)
-			assert.InDelta(t, 3, elements[1].Width, 0.001)
+				assert.Equal(t, "C", elements[1].Text)
+				assert.InDelta(t, 67.5, elements[1].X, 0.001)
+				assert.InDelta(t, 115, elements[1].Y, 0.001)
+				assert.InDelta(t, 3, elements[1].Width, 0.001)
 
-			assert.Equal(t, "D", elements[2].Text)
-			assert.InDelta(t, 10, elements[2].X, 0.001)
-			assert.InDelta(t, 20, elements[2].Y, 0.001)
-			assert.InDelta(t, 6, elements[2].Width, 0.001)
-			assert.InDelta(t, 10, elements[2].FontSize, 0.001)
-			assert.False(t, elements[2].preciseWidth, "direct-page text must retain legacy width behavior")
+				assert.Equal(t, "D", elements[2].Text)
+				assert.InDelta(t, 10, elements[2].X, 0.001)
+				assert.InDelta(t, 20, elements[2].Y, 0.001)
+				assert.InDelta(t, 6, elements[2].Width, 0.001)
+				assert.InDelta(t, 10, elements[2].FontSize, 0.001)
+				assert.False(t, elements[2].preciseWidth, "direct-page text must retain legacy width behavior")
 
-			assert.Equal(t, "AB C\nD", AssembleText(elements))
-		})
+				assert.Equal(t, "AB C\nD", AssembleText(elements))
+			})
+		}
 	}
 }
 

--- a/internal/extractor/object_resolver.go
+++ b/internal/extractor/object_resolver.go
@@ -1,0 +1,18 @@
+package extractor
+
+import "github.com/coregx/gxpdf/internal/parser"
+
+// resolveObject follows a single indirect reference using the reader's object
+// table. Non-reference objects are returned as-is. It returns nil when the
+// referenced object cannot be resolved.
+func resolveObject(reader *parser.Reader, object parser.PdfObject) parser.PdfObject {
+	reference, ok := object.(*parser.IndirectReference)
+	if !ok {
+		return object
+	}
+	resolved, err := reader.GetObject(reference.Number)
+	if err != nil {
+		return nil
+	}
+	return resolved
+}

--- a/internal/extractor/text_element.go
+++ b/internal/extractor/text_element.go
@@ -30,6 +30,11 @@ type TextElement struct {
 	Height   float64 // Height of text (in points)
 	FontName string  // Font name (e.g., "/F1", "/Helvetica")
 	FontSize float64 // Font size in points
+
+	// preciseWidth records whether Width came from the PDF font metrics rather
+	// than the legacy 0.6-em estimate. It intentionally remains internal: it is
+	// extraction metadata used to distinguish glyph kerning from word gaps.
+	preciseWidth bool
 }
 
 // NewTextElement creates a new TextElement with the given properties.

--- a/internal/extractor/text_element.go
+++ b/internal/extractor/text_element.go
@@ -13,7 +13,9 @@ import (
 //
 // Each TextElement has position information (X, Y coordinates) which is critical
 // for table extraction and layout analysis. The coordinates represent the
-// bottom-left corner of the text element in PDF coordinate space.
+// axis-aligned bottom-left corner of the text element in PDF page space. Text
+// inside Form XObjects includes the accumulated caller and Form transforms;
+// page /Rotate remains display metadata and is not applied.
 //
 // PDF Coordinate System (Section 8.3.2):
 //   - Origin (0,0) is at bottom-left of page

--- a/internal/extractor/text_extractor.go
+++ b/internal/extractor/text_extractor.go
@@ -826,7 +826,10 @@ func (te *TextExtractor) processFormXObject(xobjName string) {
 	// Push current resources and switch to XObject's resources (if present)
 	savedResources := te.pageResources
 	savedCTM := te.ctm
-	savedGraphicsDepth := len(te.graphicsStateStack)
+	// Form graphics state is isolated from its caller. Malformed content with
+	// an unmatched Q must not pop a q that belongs to the page or parent Form.
+	savedGraphicsStateStack := te.graphicsStateStack
+	te.graphicsStateStack = nil
 	te.resourceStack = append(te.resourceStack, savedResources)
 	te.xobjectDepth++
 
@@ -850,7 +853,7 @@ func (te *TextExtractor) processFormXObject(xobjName string) {
 	// Restore saved resources and depth counter
 	te.xobjectDepth--
 	te.ctm = savedCTM
-	te.graphicsStateStack = te.graphicsStateStack[:savedGraphicsDepth]
+	te.graphicsStateStack = savedGraphicsStateStack
 	if len(te.resourceStack) > 0 {
 		te.pageResources = te.resourceStack[len(te.resourceStack)-1]
 		te.resourceStack = te.resourceStack[:len(te.resourceStack)-1]

--- a/internal/extractor/text_extractor.go
+++ b/internal/extractor/text_extractor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"strings"
 
 	"github.com/coregx/gxpdf/internal/parser"
@@ -35,6 +36,18 @@ const glyphMergeGapFactor = 1.5
 // as a word boundary and receives a space.
 const wordSpaceGapFactor = 1.0
 
+// preciseGlyphGapFactor is used when the PDF provides authoritative font
+// widths. Exact widths let us preserve real word gaps without the generous
+// tolerance required by the legacy estimated-width path.
+const preciseGlyphGapFactor = 0.2
+
+// positionedGlyphFontSizeLimit identifies the Form-XObject pattern emitted by
+// Quartz and similar generators: every glyph uses a unit-sized font and a cm
+// matrix supplies the actual size and position. Direct-page/larger text keeps
+// the established raw-coordinate behavior until gxpdf's graphics and lattice
+// coordinate paths can migrate together without changing existing tables.
+const positionedGlyphFontSizeLimit = 2.0
+
 // maxXObjectDepth limits Form XObject recursion to prevent infinite loops.
 //
 // The PDF specification does not forbid cyclic XObject references, so we
@@ -63,7 +76,11 @@ type TextExtractor struct {
 	textState     *TextState
 	elements      []*TextElement
 	fontDecoders  map[string]*FontDecoder // fontName -> FontDecoder
+	fontMetrics   map[string]*fontMetrics // fontName -> glyph widths
 	pageResources *parser.Dictionary      // Current page resources
+	ctm           Matrix                  // Current transformation matrix
+
+	graphicsStateStack []textExtractorGraphicsState
 
 	// resourceStack holds the saved resource context across Form XObject calls.
 	// Each Do operator pushes the current resources; on return they are restored.
@@ -74,6 +91,10 @@ type TextExtractor struct {
 	xobjectDepth int
 }
 
+type textExtractorGraphicsState struct {
+	ctm Matrix
+}
+
 // NewTextExtractor creates a new TextExtractor for the given PDF reader.
 func NewTextExtractor(reader *parser.Reader) *TextExtractor {
 	return &TextExtractor{
@@ -81,6 +102,8 @@ func NewTextExtractor(reader *parser.Reader) *TextExtractor {
 		textState:    NewTextState(),
 		elements:     []*TextElement{},
 		fontDecoders: make(map[string]*FontDecoder),
+		fontMetrics:  make(map[string]*fontMetrics),
+		ctm:          Identity(),
 	}
 }
 
@@ -94,6 +117,9 @@ func (te *TextExtractor) ExtractFromPage(pageNum int) ([]*TextElement, error) {
 	te.elements = []*TextElement{}
 	te.textState = NewTextState()
 	te.fontDecoders = make(map[string]*FontDecoder)
+	te.fontMetrics = make(map[string]*fontMetrics)
+	te.ctm = Identity()
+	te.graphicsStateStack = nil
 
 	// Get page
 	page, err := te.reader.GetPage(pageNum)
@@ -176,13 +202,14 @@ func mergeAdjacentElements(elements []*TextElement) []*TextElement {
 		if canMerge(current, next) {
 			// Extend current element: append text and widen bounding box.
 			current = &TextElement{
-				Text:     current.Text + next.Text,
-				X:        current.X,
-				Y:        current.Y,
-				Width:    (next.X + next.Width) - current.X,
-				Height:   current.Height,
-				FontName: current.FontName,
-				FontSize: current.FontSize,
+				Text:         current.Text + next.Text,
+				X:            current.X,
+				Y:            current.Y,
+				Width:        (next.X + next.Width) - current.X,
+				Height:       current.Height,
+				FontName:     current.FontName,
+				FontSize:     current.FontSize,
+				preciseWidth: current.preciseWidth && next.preciseWidth,
 			}
 		} else {
 			// Word boundary — commit the current run and start a new one.
@@ -246,7 +273,11 @@ func canMerge(a, b *TextElement) bool {
 	}
 
 	// Positive gap: merge only if the gap is within the intra-word threshold.
-	threshold := a.FontSize * glyphMergeGapFactor
+	thresholdFactor := glyphMergeGapFactor
+	if a.preciseWidth && b.preciseWidth {
+		thresholdFactor = preciseGlyphGapFactor
+	}
+	threshold := a.FontSize * thresholdFactor
 	return gap <= threshold
 }
 
@@ -290,7 +321,11 @@ func AssembleText(elements []*TextElement) string {
 
 		// Same line: decide whether a space is needed.
 		gap := curr.X - (prev.X + prev.Width)
-		if gap > prev.FontSize*wordSpaceGapFactor {
+		gapFactor := wordSpaceGapFactor
+		if prev.preciseWidth && curr.preciseWidth {
+			gapFactor = preciseGlyphGapFactor
+		}
+		if gap > prev.FontSize*gapFactor {
 			sb.WriteByte(' ')
 		}
 		sb.WriteString(curr.Text)
@@ -466,6 +501,33 @@ func (b *bytesReaderCloser) Close() error {
 //nolint:cyclop,funlen,gocognit,gocyclo // Text operator processing inherently requires many cases
 func (te *TextExtractor) processOperator(op *Operator) {
 	switch op.Name {
+	// Graphics state operators (Section 8.4.2). Text coordinates are expressed
+	// in the current user space, so page/Form transformations must be applied.
+	case "q":
+		te.graphicsStateStack = append(te.graphicsStateStack, textExtractorGraphicsState{
+			ctm: te.ctm,
+		})
+
+	case "Q":
+		if n := len(te.graphicsStateStack); n > 0 {
+			saved := te.graphicsStateStack[n-1]
+			te.graphicsStateStack = te.graphicsStateStack[:n-1]
+			te.ctm = saved.ctm
+		}
+
+	case "cm":
+		if len(op.Operands) >= 6 {
+			values := [6]*float64{}
+			for i := range values {
+				values[i] = getNumber(op.Operands[i])
+			}
+			if values[0] != nil && values[1] != nil && values[2] != nil &&
+				values[3] != nil && values[4] != nil && values[5] != nil {
+				operand := NewMatrix(*values[0], *values[1], *values[2], *values[3], *values[4], *values[5])
+				te.ctm = te.ctm.Multiply(operand)
+			}
+		}
+
 	// Text object delimiters (Section 9.4.1)
 	case "BT": // Begin text
 		te.textState.Reset()
@@ -621,22 +683,70 @@ func (te *TextExtractor) addTextBytes(glyphBytes []byte) {
 	// Decode glyph bytes to Unicode text
 	decodedText := te.decodeTextBytes(glyphBytes)
 
-	// Get current position from text matrix
-	x := te.textState.CurrentX
-	y := te.textState.CurrentY
-
-	// Estimate width (simple heuristic - will be improved with font metrics in Phase 3)
-	// Use decoded text length for more accurate width calculation
-	charWidth := te.textState.FontSize * 0.6 * (te.textState.HorizScale / 100.0)
-	width := float64(len(decodedText)) * charWidth
-	height := te.textState.FontSize
+	advance, width, precise := te.measureGlyphBytes(glyphBytes)
+	positionedFormGeometry := te.usesPositionedFormGeometry()
+	if !positionedFormGeometry {
+		width = float64(len(decodedText)) * te.textState.FontSize * 0.6 * (te.textState.HorizScale / 100.0)
+		advance, precise = width, false
+	}
+	x, y := te.textState.CurrentX, te.textState.CurrentY
+	height, effectiveFontSize := te.textState.FontSize, te.textState.FontSize
+	if positionedFormGeometry {
+		x, y, width, height, effectiveFontSize = te.transformedTextBounds(width)
+	}
 
 	// Create text element with decoded text
-	elem := NewTextElement(decodedText, x, y, width, height, te.textState.FontName, te.textState.FontSize)
+	elem := NewTextElement(decodedText, x, y, width, height, te.textState.FontName, effectiveFontSize)
+	elem.preciseWidth = precise
 	te.elements = append(te.elements, elem)
 
 	// Advance text position
-	te.textState.AdvanceX(width)
+	te.textState.AdvanceX(advance)
+}
+
+// transformedTextBounds maps the text-space bounding box through the text
+// matrix and current transformation matrix and returns its axis-aligned bounds.
+func (te *TextExtractor) transformedTextBounds(width float64) (float64, float64, float64, float64, float64) {
+	// Existing direct-page extraction intentionally remains in raw text space
+	// for compatibility with the lattice coordinate normalizer. Form XObjects,
+	// however, cannot be positioned without inheriting the caller CTM and their
+	// own /Matrix, so apply the accumulated CTM while recursing into a Form.
+	coordinateMatrix := Identity()
+	if te.usesPositionedFormGeometry() {
+		coordinateMatrix = te.ctm
+	}
+	bottom := te.textState.Rise
+	top := bottom + te.textState.FontSize
+	points := [4][2]float64{{0, bottom}, {width, bottom}, {0, top}, {width, top}}
+
+	minX, minY := math.Inf(1), math.Inf(1)
+	maxX, maxY := math.Inf(-1), math.Inf(-1)
+	for _, point := range points {
+		tx, ty := te.textState.Tm.Transform(point[0], point[1])
+		x, y := coordinateMatrix.Transform(tx, ty)
+		minX = math.Min(minX, x)
+		minY = math.Min(minY, y)
+		maxX = math.Max(maxX, x)
+		maxY = math.Max(maxY, y)
+	}
+
+	baseX, baseY := te.textState.Tm.Transform(0, bottom)
+	topX, topY := te.textState.Tm.Transform(0, top)
+	baseX, baseY = coordinateMatrix.Transform(baseX, baseY)
+	topX, topY = coordinateMatrix.Transform(topX, topY)
+	effectiveFontSize := math.Hypot(topX-baseX, topY-baseY)
+
+	return minX, minY, maxX - minX, maxY - minY, effectiveFontSize
+}
+
+func (te *TextExtractor) usesPositionedFormGeometry() bool {
+	if te.xobjectDepth == 0 || te.textState.FontSize <= 0 {
+		return false
+	}
+	baseX, baseY := te.textState.Tm.Transform(0, te.textState.Rise)
+	topX, topY := te.textState.Tm.Transform(0, te.textState.Rise+te.textState.FontSize)
+	rawTextSize := math.Hypot(topX-baseX, topY-baseY)
+	return rawTextSize > 0 && rawTextSize <= positionedGlyphFontSizeLimit
 }
 
 // processTextArray processes a TJ array with positioning adjustments.
@@ -717,12 +827,17 @@ func (te *TextExtractor) processFormXObject(xobjName string) {
 
 	// Push current resources and switch to XObject's resources (if present)
 	savedResources := te.pageResources
+	savedCTM := te.ctm
+	savedGraphicsDepth := len(te.graphicsStateStack)
 	te.resourceStack = append(te.resourceStack, savedResources)
 	te.xobjectDepth++
 
 	xobjResources := te.getXObjectResources(xobjectStream)
 	if xobjResources != nil {
 		te.pageResources = xobjResources
+	}
+	if formMatrix, ok := te.getFormMatrix(xobjectStream); ok {
+		te.ctm = te.ctm.Multiply(formMatrix)
 	}
 
 	// Parse and process the XObject's content stream
@@ -736,12 +851,39 @@ func (te *TextExtractor) processFormXObject(xobjName string) {
 
 	// Restore saved resources and depth counter
 	te.xobjectDepth--
+	te.ctm = savedCTM
+	te.graphicsStateStack = te.graphicsStateStack[:savedGraphicsDepth]
 	if len(te.resourceStack) > 0 {
 		te.pageResources = te.resourceStack[len(te.resourceStack)-1]
 		te.resourceStack = te.resourceStack[:len(te.resourceStack)-1]
 	} else {
 		te.pageResources = savedResources
 	}
+}
+
+// getFormMatrix resolves a Form XObject's optional /Matrix entry.
+func (te *TextExtractor) getFormMatrix(stream *parser.Stream) (Matrix, bool) {
+	matrixObj := stream.Dictionary().Get("Matrix")
+	if ref, ok := matrixObj.(*parser.IndirectReference); ok {
+		resolved, err := te.reader.GetObject(ref.Number)
+		if err != nil {
+			return Matrix{}, false
+		}
+		matrixObj = resolved
+	}
+	arr, ok := matrixObj.(*parser.Array)
+	if !ok || arr.Len() != 6 {
+		return Matrix{}, false
+	}
+	values := [6]float64{}
+	for i := range values {
+		num := getNumber(arr.Get(i))
+		if num == nil {
+			return Matrix{}, false
+		}
+		values[i] = *num
+	}
+	return NewMatrix(values[0], values[1], values[2], values[3], values[4], values[5]), true
 }
 
 // resolveXObject looks up a named XObject from the current pageResources and
@@ -924,6 +1066,10 @@ func (te *TextExtractor) loadFontDecoder(fontName string) {
 		return
 	}
 
+	// Load widths alongside the decoder so positioned glyphs receive accurate
+	// bounds and word-gap detection can use a conservative threshold.
+	te.fontMetrics[fontName] = te.loadFontMetrics(fontDict)
+
 	// Extract encoding name AND Differences array
 	encodingName := ""
 	var differences map[uint16]string
@@ -962,7 +1108,7 @@ func (te *TextExtractor) loadFontDecoder(fontName string) {
 	isType0 := false
 	if subtypeObj := fontDict.Get("Subtype"); subtypeObj != nil {
 		if subtypeName, ok := subtypeObj.(*parser.Name); ok {
-			isType0 = subtypeName.Value() == "Type0"
+			isType0 = subtypeName.Value() == type0FontSubtype
 		}
 	}
 

--- a/internal/extractor/text_extractor.go
+++ b/internal/extractor/text_extractor.go
@@ -710,11 +710,9 @@ func (te *TextExtractor) transformedTextBounds(width float64) (float64, float64,
 	// Existing direct-page extraction intentionally remains in raw text space
 	// for compatibility with the lattice coordinate normalizer. Form XObjects,
 	// however, cannot be positioned without inheriting the caller CTM and their
-	// own /Matrix, so apply the accumulated CTM while recursing into a Form.
-	coordinateMatrix := Identity()
-	if te.usesPositionedFormGeometry() {
-		coordinateMatrix = te.ctm
-	}
+	// own /Matrix. The caller invokes this function only for that positioned
+	// Form path, so the accumulated CTM is always authoritative here.
+	coordinateMatrix := te.ctm
 	bottom := te.textState.Rise
 	top := bottom + te.textState.FontSize
 	points := [4][2]float64{{0, bottom}, {width, bottom}, {0, top}, {width, top}}

--- a/internal/extractor/text_extractor.go
+++ b/internal/extractor/text_extractor.go
@@ -92,7 +92,38 @@ type TextExtractor struct {
 }
 
 type textExtractorGraphicsState struct {
-	ctm Matrix
+	ctm        Matrix
+	fontName   string
+	fontSize   float64
+	charSpace  float64
+	wordSpace  float64
+	horizScale float64
+	leading    float64
+	rise       float64
+}
+
+func (te *TextExtractor) currentGraphicsState() textExtractorGraphicsState {
+	return textExtractorGraphicsState{
+		ctm:        te.ctm,
+		fontName:   te.textState.FontName,
+		fontSize:   te.textState.FontSize,
+		charSpace:  te.textState.CharSpace,
+		wordSpace:  te.textState.WordSpace,
+		horizScale: te.textState.HorizScale,
+		leading:    te.textState.Leading,
+		rise:       te.textState.Rise,
+	}
+}
+
+func (te *TextExtractor) restoreGraphicsState(state textExtractorGraphicsState) {
+	te.ctm = state.ctm
+	te.textState.FontName = state.fontName
+	te.textState.FontSize = state.fontSize
+	te.textState.CharSpace = state.charSpace
+	te.textState.WordSpace = state.wordSpace
+	te.textState.HorizScale = state.horizScale
+	te.textState.Leading = state.leading
+	te.textState.Rise = state.rise
 }
 
 // NewTextExtractor creates a new TextExtractor for the given PDF reader.
@@ -504,15 +535,13 @@ func (te *TextExtractor) processOperator(op *Operator) {
 	// Graphics state operators (Section 8.4.2). Text coordinates are expressed
 	// in the current user space, so page/Form transformations must be applied.
 	case "q":
-		te.graphicsStateStack = append(te.graphicsStateStack, textExtractorGraphicsState{
-			ctm: te.ctm,
-		})
+		te.graphicsStateStack = append(te.graphicsStateStack, te.currentGraphicsState())
 
 	case "Q":
 		if n := len(te.graphicsStateStack); n > 0 {
 			saved := te.graphicsStateStack[n-1]
 			te.graphicsStateStack = te.graphicsStateStack[:n-1]
-			te.ctm = saved.ctm
+			te.restoreGraphicsState(saved)
 		}
 
 	case "cm":
@@ -773,7 +802,7 @@ func (te *TextExtractor) processTextArray(arr *parser.Array) {
 			if num := getNumber(obj); num != nil {
 				// Negative values move forward, positive values move backward
 				// The unit is 1/1000 of a text space unit
-				adjustment := -*num / 1000.0 * te.textState.FontSize
+				adjustment := -*num / 1000.0 * te.textState.FontSize * (te.textState.HorizScale / 100.0)
 				te.textState.AdvanceX(adjustment)
 			}
 		}
@@ -825,7 +854,9 @@ func (te *TextExtractor) processFormXObject(xobjName string) {
 
 	// Push current resources and switch to XObject's resources (if present)
 	savedResources := te.pageResources
-	savedCTM := te.ctm
+	savedGraphicsState := te.currentGraphicsState()
+	savedFontDecoders := te.fontDecoders
+	savedFontMetrics := te.fontMetrics
 	// Form graphics state is isolated from its caller. Malformed content with
 	// an unmatched Q must not pop a q that belongs to the page or parent Form.
 	savedGraphicsStateStack := te.graphicsStateStack
@@ -836,6 +867,11 @@ func (te *TextExtractor) processFormXObject(xobjName string) {
 	xobjResources := te.getXObjectResources(xobjectStream)
 	if xobjResources != nil {
 		te.pageResources = xobjResources
+		// Resource names are local to their dictionary. A page and two Forms may
+		// all define /F1 as different fonts, so decoder and metric caches must
+		// follow the same scope as pageResources.
+		te.fontDecoders = make(map[string]*FontDecoder)
+		te.fontMetrics = make(map[string]*fontMetrics)
 	}
 	if formMatrix, ok := te.getFormMatrix(xobjectStream); ok {
 		te.ctm = te.ctm.Multiply(formMatrix)
@@ -852,8 +888,12 @@ func (te *TextExtractor) processFormXObject(xobjName string) {
 
 	// Restore saved resources and depth counter
 	te.xobjectDepth--
-	te.ctm = savedCTM
+	te.restoreGraphicsState(savedGraphicsState)
 	te.graphicsStateStack = savedGraphicsStateStack
+	if xobjResources != nil {
+		te.fontDecoders = savedFontDecoders
+		te.fontMetrics = savedFontMetrics
+	}
 	if len(te.resourceStack) > 0 {
 		te.pageResources = te.resourceStack[len(te.resourceStack)-1]
 		te.resourceStack = te.resourceStack[:len(te.resourceStack)-1]
@@ -1012,9 +1052,9 @@ func (te *TextExtractor) getPageResources(page *parser.Dictionary) *parser.Dicti
 // If the font cannot be loaded or has no ToUnicode CMap, we create
 // a default decoder that will use fallback encoding (Latin-1).
 func (te *TextExtractor) loadFontDecoder(fontName string) {
-	// fontMetrics shares the same per-page cache lifecycle as fontDecoders.
-	// If the decoder already exists, it was loaded in this extraction pass
-	// and the associated metrics are still valid.
+	// fontMetrics shares the same resource-scope lifecycle as fontDecoders.
+	// ExtractFromPage resets the page caches, and processFormXObject swaps both
+	// caches when a Form supplies its own Resources dictionary.
 	if _, exists := te.fontDecoders[fontName]; exists {
 		return
 	}

--- a/internal/extractor/text_extractor.go
+++ b/internal/extractor/text_extractor.go
@@ -41,13 +41,6 @@ const wordSpaceGapFactor = 1.0
 // tolerance required by the legacy estimated-width path.
 const preciseGlyphGapFactor = 0.2
 
-// positionedGlyphFontSizeLimit identifies the Form-XObject pattern emitted by
-// Quartz and similar generators: every glyph uses a unit-sized font and a cm
-// matrix supplies the actual size and position. Direct-page/larger text keeps
-// the established raw-coordinate behavior until gxpdf's graphics and lattice
-// coordinate paths can migrate together without changing existing tables.
-const positionedGlyphFontSizeLimit = 2.0
-
 // maxXObjectDepth limits Form XObject recursion to prevent infinite loops.
 //
 // The PDF specification does not forbid cyclic XObject references, so we
@@ -713,14 +706,14 @@ func (te *TextExtractor) addTextBytes(glyphBytes []byte) {
 	decodedText := te.decodeTextBytes(glyphBytes)
 
 	advance, width, precise := te.measureGlyphBytes(glyphBytes)
-	positionedFormGeometry := te.usesPositionedFormGeometry()
-	if !positionedFormGeometry {
+	formGeometry := te.usesFormGeometry()
+	if !formGeometry {
 		width = float64(len(decodedText)) * te.textState.FontSize * 0.6 * (te.textState.HorizScale / 100.0)
 		advance, precise = width, false
 	}
 	x, y := te.textState.CurrentX, te.textState.CurrentY
 	height, effectiveFontSize := te.textState.FontSize, te.textState.FontSize
-	if positionedFormGeometry {
+	if formGeometry {
 		x, y, width, height, effectiveFontSize = te.transformedTextBounds(width)
 	}
 
@@ -733,14 +726,14 @@ func (te *TextExtractor) addTextBytes(glyphBytes []byte) {
 	te.textState.AdvanceX(advance)
 }
 
-// transformedTextBounds maps the text-space bounding box through the text
-// matrix and current transformation matrix and returns its axis-aligned bounds.
+// transformedTextBounds maps a Form's text-space bounding box through the text
+// matrix and accumulated page/Form transformation matrix, then returns its
+// axis-aligned page-space bounds.
 func (te *TextExtractor) transformedTextBounds(width float64) (float64, float64, float64, float64, float64) {
-	// Existing direct-page extraction intentionally remains in raw text space
-	// for compatibility with the lattice coordinate normalizer. Form XObjects,
-	// however, cannot be positioned without inheriting the caller CTM and their
-	// own /Matrix. The caller invokes this function only for that positioned
-	// Form path, so the accumulated CTM is always authoritative here.
+	// Direct-page extraction remains in its established raw text space. Every
+	// Form XObject, regardless of font size, inherits its caller CTM and /Matrix;
+	// using a size-dependent coordinate path would make otherwise equivalent
+	// Form text report different positions at an arbitrary threshold.
 	coordinateMatrix := te.ctm
 	bottom := te.textState.Rise
 	top := bottom + te.textState.FontSize
@@ -766,14 +759,8 @@ func (te *TextExtractor) transformedTextBounds(width float64) (float64, float64,
 	return minX, minY, maxX - minX, maxY - minY, effectiveFontSize
 }
 
-func (te *TextExtractor) usesPositionedFormGeometry() bool {
-	if te.xobjectDepth == 0 || te.textState.FontSize <= 0 {
-		return false
-	}
-	baseX, baseY := te.textState.Tm.Transform(0, te.textState.Rise)
-	topX, topY := te.textState.Tm.Transform(0, te.textState.Rise+te.textState.FontSize)
-	rawTextSize := math.Hypot(topX-baseX, topY-baseY)
-	return rawTextSize > 0 && rawTextSize <= positionedGlyphFontSizeLimit
+func (te *TextExtractor) usesFormGeometry() bool {
+	return te.xobjectDepth > 0 && te.textState.FontSize > 0
 }
 
 // processTextArray processes a TJ array with positioning adjustments.

--- a/internal/extractor/text_extractor.go
+++ b/internal/extractor/text_extractor.go
@@ -1012,7 +1012,9 @@ func (te *TextExtractor) getPageResources(page *parser.Dictionary) *parser.Dicti
 // If the font cannot be loaded or has no ToUnicode CMap, we create
 // a default decoder that will use fallback encoding (Latin-1).
 func (te *TextExtractor) loadFontDecoder(fontName string) {
-	// Check if already loaded
+	// fontMetrics shares the same per-page cache lifecycle as fontDecoders.
+	// If the decoder already exists, it was loaded in this extraction pass
+	// and the associated metrics are still valid.
 	if _, exists := te.fontDecoders[fontName]; exists {
 		return
 	}

--- a/testdata/generators/form_large_text_table.go
+++ b/testdata/generators/form_large_text_table.go
@@ -1,0 +1,77 @@
+//go:build ignore
+
+// Generator for testdata/pdfs/form_large_text_table.pdf.
+//
+// The table text uses an ordinary 12-point font inside a Form XObject. The
+// ruling lines live directly in page content, so lattice extraction only works
+// when Form and direct-page geometry share page space.
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type pdfObject []byte
+
+func main() {
+	formContent := strings.Join([]string{
+		"BT /F1 12 Tf 1 0 0 1 100 650 Tm (Line Item) Tj ET",
+		"BT /F1 12 Tf 1 0 0 1 350 650 Tm (2023) Tj ET",
+		"BT /F1 12 Tf 1 0 0 1 450 650 Tm (2024) Tj ET",
+		"BT /F1 12 Tf 1 0 0 1 100 620 Tm (Revenue) Tj ET",
+		"BT /F1 12 Tf 1 0 0 1 350 620 Tm (1200) Tj ET",
+		"BT /F1 12 Tf 1 0 0 1 450 620 Tm (1450) Tj ET",
+		"BT /F1 12 Tf 1 0 0 1 100 590 Tm (Cost of Sales) Tj ET",
+		"BT /F1 12 Tf 1 0 0 1 350 590 Tm ((400)) Tj ET",
+		"BT /F1 12 Tf 1 0 0 1 450 590 Tm ((570)) Tj ET",
+	}, "\n")
+	pageContent := strings.Join([]string{
+		"50 640 250 25 re S 300 640 100 25 re S 400 640 120 25 re S",
+		"50 610 250 30 re S 300 610 100 30 re S 400 610 120 30 re S",
+		"50 580 250 30 re S 300 580 100 30 re S 400 580 120 30 re S",
+		"/Fm1 Do",
+	}, "\n")
+	fontWidths := strings.TrimSpace(strings.Repeat("600 ", 95))
+	objects := []pdfObject{
+		pdfObject("<< /Type /Catalog /Pages 2 0 R >>"),
+		pdfObject("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+		pdfObject("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /Fm1 5 0 R >> >> /Contents 4 0 R >>"),
+		streamObject([]byte(pageContent), ""),
+		streamObject([]byte(formContent), "/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Resources << /Font << /F1 6 0 R >> >>"),
+		pdfObject(fmt.Sprintf("<< /Type /Font /Subtype /TrueType /BaseFont /Synthetic /FirstChar 32 /LastChar 126 /Widths [%s] >>", fontWidths)),
+	}
+	path := filepath.Join("testdata", "pdfs", "form_large_text_table.pdf")
+	if err := os.WriteFile(path, buildPDF(objects), 0o644); err != nil {
+		panic(err)
+	}
+}
+
+func streamObject(data []byte, extra string) pdfObject {
+	prefix := fmt.Sprintf("<< %s /Length %d >>\nstream\n", extra, len(data))
+	result := append([]byte(prefix), data...)
+	return append(result, []byte("\nendstream")...)
+}
+
+func buildPDF(objects []pdfObject) []byte {
+	var output bytes.Buffer
+	output.WriteString("%PDF-1.7\n%\xE2\xE3\xCF\xD3\n")
+	offsets := make([]int, len(objects)+1)
+	for index, object := range objects {
+		offsets[index+1] = output.Len()
+		fmt.Fprintf(&output, "%d 0 obj\n", index+1)
+		output.Write(object)
+		output.WriteString("\nendobj\n")
+	}
+	xref := output.Len()
+	fmt.Fprintf(&output, "xref\n0 %d\n", len(objects)+1)
+	output.WriteString("0000000000 65535 f\n")
+	for _, offset := range offsets[1:] {
+		fmt.Fprintf(&output, "%010d 00000 n\n", offset)
+	}
+	fmt.Fprintf(&output, "trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", len(objects)+1, xref)
+	return output.Bytes()
+}

--- a/testdata/generators/form_positioned_table.go
+++ b/testdata/generators/form_positioned_table.go
@@ -1,0 +1,101 @@
+//go:build ignore
+
+// Generator for testdata/pdfs/form_positioned_table.pdf.
+//
+// It mimics PDF generators that place unit-sized glyphs at the text origin and
+// supply their real page position through nested page/Form/glyph transforms.
+// Run from the repository root with:
+//
+//	go run testdata/generators/form_positioned_table.go
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type pdfObject []byte
+
+func main() {
+	formContent := strings.Join([]string{
+		positionedGlyphRun(100, 700, "Income Statement"),
+		positionedGlyphRun(100, 650, "Line Item"),
+		positionedGlyphRun(350, 650, "2023"),
+		positionedGlyphRun(450, 650, "2024"),
+		positionedGlyphRun(100, 620, "Revenue"),
+		positionedGlyphRun(350, 620, "1200"),
+		positionedGlyphRun(450, 620, "1450"),
+		positionedGlyphRun(100, 590, "Cost of Sales"),
+		positionedGlyphRun(350, 590, "(400)"),
+		positionedGlyphRun(450, 590, "(570)"),
+	}, "\n")
+	fontWidths := strings.TrimSpace(strings.Repeat("600 ", 95))
+	pageContent := strings.Join([]string{
+		// A direct-page grid surrounds the three transformed text columns.
+		"50 350 m 270 350 l 270 302 l 50 302 l h S",
+		"170 350 m 170 302 l S",
+		"220 350 m 220 302 l S",
+		"50 332 m 270 332 l S",
+		"50 317 m 270 317 l S",
+		"q 0.5 0 0 0.5 0 0 cm /Fm1 Do Q",
+	}, "\n")
+	objects := []pdfObject{
+		pdfObject("<< /Type /Catalog /Pages 2 0 R >>"),
+		pdfObject("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+		pdfObject("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /Fm1 5 0 R >> >> /Contents 4 0 R >>"),
+		streamObject([]byte(pageContent), ""),
+		streamObject([]byte(formContent), "/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Matrix [1 0 0 1 20 30] /Resources << /Font << /F1 6 0 R >> >>"),
+		pdfObject(fmt.Sprintf("<< /Type /Font /Subtype /TrueType /BaseFont /Synthetic /FirstChar 32 /LastChar 126 /Widths [%s] >>", fontWidths)),
+	}
+	path := filepath.Join("testdata", "pdfs", "form_positioned_table.pdf")
+	if err := os.WriteFile(path, buildPDF(objects), 0o644); err != nil {
+		panic(err)
+	}
+}
+
+func positionedGlyphRun(x, y int, value string) string {
+	var content strings.Builder
+	for _, glyph := range value {
+		fmt.Fprintf(&content, "q 10 0 0 10 %d %d cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (%s) Tj ET Q\n", x, y, escapePDFText(string(glyph)))
+		x += 6
+	}
+	return strings.TrimSpace(content.String())
+}
+
+func streamObject(data []byte, extra string) pdfObject {
+	prefix := fmt.Sprintf("<< %s /Length %d >>\nstream\n", extra, len(data))
+	result := make([]byte, 0, len(prefix)+len(data)+11)
+	result = append(result, prefix...)
+	result = append(result, data...)
+	result = append(result, []byte("\nendstream")...)
+	return result
+}
+
+func buildPDF(objects []pdfObject) []byte {
+	var out bytes.Buffer
+	out.WriteString("%PDF-1.7\n%\xE2\xE3\xCF\xD3\n")
+	offsets := make([]int, len(objects)+1)
+	for index, object := range objects {
+		offsets[index+1] = out.Len()
+		fmt.Fprintf(&out, "%d 0 obj\n", index+1)
+		out.Write(object)
+		out.WriteString("\nendobj\n")
+	}
+	xref := out.Len()
+	fmt.Fprintf(&out, "xref\n0 %d\n", len(objects)+1)
+	out.WriteString("0000000000 65535 f\n")
+	for _, offset := range offsets[1:] {
+		fmt.Fprintf(&out, "%010d 00000 n\n", offset)
+	}
+	fmt.Fprintf(&out, "trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", len(objects)+1, xref)
+	return out.Bytes()
+}
+
+func escapePDFText(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, "(", `\(`)
+	return strings.ReplaceAll(value, ")", `\)`)
+}

--- a/testdata/generators/form_text_sizes.go
+++ b/testdata/generators/form_text_sizes.go
@@ -4,6 +4,8 @@
 //
 // The fixture places four otherwise-equivalent text runs in a transformed Form
 // XObject at font sizes around the former two-unit compatibility threshold.
+// The page has /Rotate 90 to prove display metadata does not alter user-space
+// bounds.
 // Run from the repository root with:
 //
 //	go run testdata/generators/form_text_sizes.go
@@ -29,7 +31,7 @@ func main() {
 	objects := []pdfObject{
 		pdfObject("<< /Type /Catalog /Pages 2 0 R >>"),
 		pdfObject("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
-		pdfObject("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /Fm1 5 0 R >> >> /Contents 4 0 R >>"),
+		pdfObject("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Rotate 90 /Resources << /XObject << /Fm1 5 0 R >> >> /Contents 4 0 R >>"),
 		streamObject([]byte("q 0.5 0 0 0.5 100 50 cm /Fm1 Do Q"), ""),
 		streamObject([]byte(formContent), "/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Matrix [2 0 0 3 10 20] /Resources << /Font << /F1 6 0 R >> >>"),
 		pdfObject("<< /Type /Font /Subtype /TrueType /BaseFont /Synthetic /FirstChar 65 /LastChar 68 /Widths [600 600 600 600] >>"),

--- a/testdata/generators/form_text_sizes.go
+++ b/testdata/generators/form_text_sizes.go
@@ -1,0 +1,70 @@
+//go:build ignore
+
+// Generator for testdata/pdfs/form_text_sizes.pdf.
+//
+// The fixture places four otherwise-equivalent text runs in a transformed Form
+// XObject at font sizes around the former two-unit compatibility threshold.
+// Run from the repository root with:
+//
+//	go run testdata/generators/form_text_sizes.go
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type pdfObject []byte
+
+func main() {
+	formContent := strings.Join([]string{
+		"BT /F1 1 Tf 1 0 0 1 10 100 Tm (A) Tj ET",
+		"BT /F1 2 Tf 1 0 0 1 10 140 Tm (B) Tj ET",
+		"BT /F1 2.01 Tf 1 0 0 1 10 180 Tm (C) Tj ET",
+		"BT /F1 12 Tf 1 0 0 1 10 220 Tm (D) Tj ET",
+	}, "\n")
+	objects := []pdfObject{
+		pdfObject("<< /Type /Catalog /Pages 2 0 R >>"),
+		pdfObject("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+		pdfObject("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /Fm1 5 0 R >> >> /Contents 4 0 R >>"),
+		streamObject([]byte("q 0.5 0 0 0.5 100 50 cm /Fm1 Do Q"), ""),
+		streamObject([]byte(formContent), "/Type /XObject /Subtype /Form /BBox [0 0 612 792] /Matrix [2 0 0 3 10 20] /Resources << /Font << /F1 6 0 R >> >>"),
+		pdfObject("<< /Type /Font /Subtype /TrueType /BaseFont /Synthetic /FirstChar 65 /LastChar 68 /Widths [600 600 600 600] >>"),
+	}
+	path := filepath.Join("testdata", "pdfs", "form_text_sizes.pdf")
+	if err := os.WriteFile(path, buildPDF(objects), 0o644); err != nil {
+		panic(err)
+	}
+}
+
+func streamObject(data []byte, extra string) pdfObject {
+	prefix := fmt.Sprintf("<< %s /Length %d >>\nstream\n", extra, len(data))
+	result := make([]byte, 0, len(prefix)+len(data)+11)
+	result = append(result, prefix...)
+	result = append(result, data...)
+	result = append(result, []byte("\nendstream")...)
+	return result
+}
+
+func buildPDF(objects []pdfObject) []byte {
+	var output bytes.Buffer
+	output.WriteString("%PDF-1.7\n%\xE2\xE3\xCF\xD3\n")
+	offsets := make([]int, len(objects)+1)
+	for index, object := range objects {
+		offsets[index+1] = output.Len()
+		fmt.Fprintf(&output, "%d 0 obj\n", index+1)
+		output.Write(object)
+		output.WriteString("\nendobj\n")
+	}
+	xref := output.Len()
+	fmt.Fprintf(&output, "xref\n0 %d\n", len(objects)+1)
+	output.WriteString("0000000000 65535 f\n")
+	for _, offset := range offsets[1:] {
+		fmt.Fprintf(&output, "%010d 00000 n\n", offset)
+	}
+	fmt.Fprintf(&output, "trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", len(objects)+1, xref)
+	return output.Bytes()
+}

--- a/testdata/golden/form_large_text_table0.json
+++ b/testdata/golden/form_large_text_table0.json
@@ -1,0 +1,44 @@
+{
+  "pdf": "testdata/pdfs/form_large_text_table.pdf",
+  "page": 0,
+  "method": "Lattice",
+  "rows": 3,
+  "cols": 3,
+  "cells": [
+    {
+      "row": 0,
+      "col": 0,
+      "text": "Line Item 2023 2024",
+      "rowSpan": 1,
+      "colSpan": 3
+    },
+    {
+      "row": 1,
+      "col": 0,
+      "text": "Revenue",
+      "rowSpan": 1,
+      "colSpan": 1
+    },
+    {
+      "row": 1,
+      "col": 1,
+      "text": "1200",
+      "rowSpan": 1,
+      "colSpan": 1
+    },
+    {
+      "row": 1,
+      "col": 2,
+      "text": "1450",
+      "rowSpan": 1,
+      "colSpan": 1
+    },
+    {
+      "row": 2,
+      "col": 0,
+      "text": "Cost of Sales (400) (570)",
+      "rowSpan": 1,
+      "colSpan": 3
+    }
+  ]
+}

--- a/testdata/pdfs/form_large_text_table.pdf
+++ b/testdata/pdfs/form_large_text_table.pdf
@@ -1,0 +1,51 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /Fm1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<<  /Length 184 >>
+stream
+50 640 250 25 re S 300 640 100 25 re S 400 640 120 25 re S
+50 610 250 30 re S 300 610 100 30 re S 400 610 120 30 re S
+50 580 250 30 re S 300 580 100 30 re S 400 580 120 30 re S
+/Fm1 Do
+endstream
+endobj
+5 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 612 792] /Resources << /Font << /F1 6 0 R >> >> /Length 423 >>
+stream
+BT /F1 12 Tf 1 0 0 1 100 650 Tm (Line Item) Tj ET
+BT /F1 12 Tf 1 0 0 1 350 650 Tm (2023) Tj ET
+BT /F1 12 Tf 1 0 0 1 450 650 Tm (2024) Tj ET
+BT /F1 12 Tf 1 0 0 1 100 620 Tm (Revenue) Tj ET
+BT /F1 12 Tf 1 0 0 1 350 620 Tm (1200) Tj ET
+BT /F1 12 Tf 1 0 0 1 450 620 Tm (1450) Tj ET
+BT /F1 12 Tf 1 0 0 1 100 590 Tm (Cost of Sales) Tj ET
+BT /F1 12 Tf 1 0 0 1 350 590 Tm ((400)) Tj ET
+BT /F1 12 Tf 1 0 0 1 450 590 Tm ((570)) Tj ET
+endstream
+endobj
+6 0 obj
+<< /Type /Font /Subtype /TrueType /BaseFont /Synthetic /FirstChar 32 /LastChar 126 /Widths [600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600] >>
+endobj
+xref
+0 7
+0000000000 65535 f
+0000000015 00000 n
+0000000064 00000 n
+0000000121 00000 n
+0000000251 00000 n
+0000000487 00000 n
+0000001050 00000 n
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+1541
+%%EOF

--- a/testdata/pdfs/form_positioned_table.pdf
+++ b/testdata/pdfs/form_positioned_table.pdf
@@ -1,0 +1,115 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /Fm1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<<  /Length 158 >>
+stream
+50 350 m 270 350 l 270 302 l 50 302 l h S
+170 350 m 170 302 l S
+220 350 m 220 302 l S
+50 332 m 270 332 l S
+50 317 m 270 317 l S
+q 0.5 0 0 0.5 0 0 cm /Fm1 Do Q
+endstream
+endobj
+5 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 612 792] /Matrix [1 0 0 1 20 30] /Resources << /Font << /F1 6 0 R >> >> /Length 4405 >>
+stream
+q 10 0 0 10 100 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (I) Tj ET Q
+q 10 0 0 10 106 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 112 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (c) Tj ET Q
+q 10 0 0 10 118 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (o) Tj ET Q
+q 10 0 0 10 124 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (m) Tj ET Q
+q 10 0 0 10 130 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 136 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 142 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (S) Tj ET Q
+q 10 0 0 10 148 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 154 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (a) Tj ET Q
+q 10 0 0 10 160 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 166 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 172 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (m) Tj ET Q
+q 10 0 0 10 178 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 184 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 190 700 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 100 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (L) Tj ET Q
+q 10 0 0 10 106 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (i) Tj ET Q
+q 10 0 0 10 112 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 118 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 124 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 130 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (I) Tj ET Q
+q 10 0 0 10 136 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 142 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 148 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (m) Tj ET Q
+q 10 0 0 10 350 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 356 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 362 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 368 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (3) Tj ET Q
+q 10 0 0 10 450 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 456 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 462 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 468 650 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (4) Tj ET Q
+q 10 0 0 10 100 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (R) Tj ET Q
+q 10 0 0 10 106 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 112 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (v) Tj ET Q
+q 10 0 0 10 118 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 124 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (n) Tj ET Q
+q 10 0 0 10 130 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (u) Tj ET Q
+q 10 0 0 10 136 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 350 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (1) Tj ET Q
+q 10 0 0 10 356 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (2) Tj ET Q
+q 10 0 0 10 362 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 368 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 450 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (1) Tj ET Q
+q 10 0 0 10 456 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (4) Tj ET Q
+q 10 0 0 10 462 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (5) Tj ET Q
+q 10 0 0 10 468 620 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 100 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (C) Tj ET Q
+q 10 0 0 10 106 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (o) Tj ET Q
+q 10 0 0 10 112 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (s) Tj ET Q
+q 10 0 0 10 118 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (t) Tj ET Q
+q 10 0 0 10 124 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 130 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (o) Tj ET Q
+q 10 0 0 10 136 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (f) Tj ET Q
+q 10 0 0 10 142 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm ( ) Tj ET Q
+q 10 0 0 10 148 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (S) Tj ET Q
+q 10 0 0 10 154 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (a) Tj ET Q
+q 10 0 0 10 160 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (l) Tj ET Q
+q 10 0 0 10 166 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (e) Tj ET Q
+q 10 0 0 10 172 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (s) Tj ET Q
+q 10 0 0 10 350 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\() Tj ET Q
+q 10 0 0 10 356 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (4) Tj ET Q
+q 10 0 0 10 362 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 368 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 374 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\)) Tj ET Q
+q 10 0 0 10 450 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\() Tj ET Q
+q 10 0 0 10 456 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (5) Tj ET Q
+q 10 0 0 10 462 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (7) Tj ET Q
+q 10 0 0 10 468 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (0) Tj ET Q
+q 10 0 0 10 474 590 cm BT /F1 1 Tf 1 0 0 1 0 0 Tm (\)) Tj ET Q
+endstream
+endobj
+6 0 obj
+<< /Type /Font /Subtype /TrueType /BaseFont /Synthetic /FirstChar 32 /LastChar 126 /Widths [600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600] >>
+endobj
+xref
+0 7
+0000000000 65535 f
+0000000015 00000 n
+0000000064 00000 n
+0000000121 00000 n
+0000000251 00000 n
+0000000461 00000 n
+0000005031 00000 n
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+5522
+%%EOF

--- a/testdata/pdfs/form_text_sizes.pdf
+++ b/testdata/pdfs/form_text_sizes.pdf
@@ -7,7 +7,7 @@ endobj
 << /Type /Pages /Kids [3 0 R] /Count 1 >>
 endobj
 3 0 obj
-<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /Fm1 5 0 R >> >> /Contents 4 0 R >>
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Rotate 90 /Resources << /XObject << /Fm1 5 0 R >> >> /Contents 4 0 R >>
 endobj
 4 0 obj
 <<  /Length 33 >>
@@ -33,11 +33,11 @@ xref
 0000000015 00000 n
 0000000064 00000 n
 0000000121 00000 n
-0000000251 00000 n
-0000000335 00000 n
-0000000662 00000 n
+0000000262 00000 n
+0000000346 00000 n
+0000000673 00000 n
 trailer
 << /Size 7 /Root 1 0 R >>
 startxref
-788
+799
 %%EOF

--- a/testdata/pdfs/form_text_sizes.pdf
+++ b/testdata/pdfs/form_text_sizes.pdf
@@ -1,0 +1,43 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /XObject << /Fm1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<<  /Length 33 >>
+stream
+q 0.5 0 0 0.5 100 50 cm /Fm1 Do Q
+endstream
+endobj
+5 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 612 792] /Matrix [2 0 0 3 10 20] /Resources << /Font << /F1 6 0 R >> >> /Length 163 >>
+stream
+BT /F1 1 Tf 1 0 0 1 10 100 Tm (A) Tj ET
+BT /F1 2 Tf 1 0 0 1 10 140 Tm (B) Tj ET
+BT /F1 2.01 Tf 1 0 0 1 10 180 Tm (C) Tj ET
+BT /F1 12 Tf 1 0 0 1 10 220 Tm (D) Tj ET
+endstream
+endobj
+6 0 obj
+<< /Type /Font /Subtype /TrueType /BaseFont /Synthetic /FirstChar 65 /LastChar 68 /Widths [600 600 600 600] >>
+endobj
+xref
+0 7
+0000000000 65535 f
+0000000015 00000 n
+0000000064 00000 n
+0000000121 00000 n
+0000000251 00000 n
+0000000335 00000 n
+0000000662 00000 n
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+788
+%%EOF


### PR DESCRIPTION
## Summary

- apply accumulated caller and Form transformations to Form XObject text at every positive font size
- remove the size-dependent Form-coordinate discontinuity at the former two-unit compatibility threshold
- preserve the established direct-page coordinate path and page `/Rotate` behavior
- document and test this as a bounded compatibility step toward the broader page-space model

Refs #96. This PR deliberately does **not** close #96.

## Scope boundary

Issue #96 also calls for migrating direct-page text and retiring or auditing the lattice `CoordinateNormalizer`. Applying the Form model to direct-page text currently changes established table goldens and drops the repository's course-table ground-truth result below its required threshold. That larger migration therefore remains open in #96 and needs coordinated text, graphics, and table work. This draft removes only the arbitrary two-unit cutoff from the already-corrected Form path, without taking that regression.

## Dependency

This draft depends on #90. Once #90 lands, GitHub will reduce this PR to its all-font-size compatibility commits automatically.

## Test coverage

- committed `form_text_sizes.pdf` fixture with Form text at 1, 2, 2.01, and 12 units plus page `/Rotate 90`
- exact public-API assertions for position, width, height, and effective font size on both sides of the former threshold
- explicit duplicate detection and exactly-once assertions for every expected fixture label
- table-driven Form bounds for rotation, skew, reflection, non-uniform scale, text rise, and horizontal scaling
- page `/Rotate` coverage at 0, 90, 180, and 270 degrees for both `Tj` and `TJ`
- repeated invocation of one cached Form under distinct translation and non-uniform scaling, with exact independent bounds
- nested page `cm` plus two Form `/Matrix` transforms with exact coordinate assertions
- committed ruled-table fixture with ordinary 12-point Form text and a reviewed Lattice golden snapshot
- deterministic generators for both new PDF fixtures
- #90's existing Tj/TJ, glyph-transform, state-isolation, and direct-page compatibility tests remain green

The Lattice golden deliberately freezes the current geometry-to-table handoff, including the detector's existing merged header and cost-row cells. It is not asserting that those merged cells are the desired final segmentation; improving that independent table-reconstruction behavior remains outside this geometry-only PR.

## Verification

- `GOTOOLCHAIN=go1.25.7 go vet ./...`
- `GOTOOLCHAIN=go1.25.7 go test -race ./...`
- `golangci-lint v2.11.0 run --timeout=5m`
- formatting and diff checks
- Linux/386 cross-build
